### PR TITLE
Remove dashes after the colon at every language file

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -857,7 +857,7 @@ STR_0852    :{WINDOW_COLOUR_2}Graphics by Simon Foster
 STR_0853    :{WINDOW_COLOUR_2}Sound and music by Allister Brimble
 STR_0854    :{WINDOW_COLOUR_2}Additional sounds recorded by David Ellis
 STR_0855    :{WINDOW_COLOUR_2}Representation by Jacqui Lyons at Marjacq Ltd.
-STR_0856    :{WINDOW_COLOUR_2}Thanks to:-
+STR_0856    :{WINDOW_COLOUR_2}Thanks to:
 STR_0857    :{WINDOW_COLOUR_2}Peter James Adcock, Joe Booth, and John Wardley
 STR_0858    :{WINDOW_COLOUR_2}
 STR_0859    :{WINDOW_COLOUR_2}
@@ -1059,7 +1059,7 @@ STR_1054    :{SMALLFONT}{BLACK}Name ride/attraction
 STR_1055    :{SMALLFONT}{BLACK}Name person
 STR_1056    :{SMALLFONT}{BLACK}Name staff member
 STR_1057    :Ride/attraction name
-STR_1058    :Enter new name for this ride/attraction:-
+STR_1058    :Enter new name for this ride/attraction:
 STR_1059    :Can't rename ride/attraction...
 STR_1060    :Invalid ride/attraction name
 STR_1061    :Normal mode
@@ -1454,7 +1454,7 @@ STR_1449    :{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1450    :{INLINE_SPRITE}{09}{20}{00}{00}{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1451    :{STRINGID}{NEWLINE}({STRINGID})
 STR_1452    :Guest's name
-STR_1453    :Enter name for this guest:-
+STR_1453    :Enter name for this guest:
 STR_1454    :Can't name guest...
 STR_1455    :Invalid name for guest
 STR_1456    :{WINDOW_COLOUR_2}Cash spent: {BLACK}{CURRENCY2DP}
@@ -1720,7 +1720,7 @@ STR_1715    :{INLINE_SPRITE}{250}{19}{00}{00}{WINDOW_COLOUR_2}Mow grass
 STR_1716    :Invalid name for park
 STR_1717    :Can't rename park...
 STR_1718    :Park Name
-STR_1719    :Enter name for park:-
+STR_1719    :Enter name for park:
 STR_1720    :{SMALLFONT}{BLACK}Name park
 STR_1721    :Park closed
 STR_1722    :Park open
@@ -1894,7 +1894,7 @@ STR_1889    :{WINDOW_COLOUR_2}Down-Time: {MOVE_X}{255}{BLACK}{COMMA16}%
 STR_1890    :{SMALLFONT}{BLACK}Select how often a mechanic should check this ride
 STR_1891    :No {STRINGID} in park yet!
 STR_1892    :RollerCoaster Tycoon 2
-STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:-
+STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:
 STR_1894    :{WINDOW_COLOUR_2}{STRINGID} sold: {BLACK}{COMMA32}
 STR_1895    :{SMALLFONT}{BLACK}Build new ride/attraction
 STR_1896    :{WINDOW_COLOUR_2}Expenditure/Income
@@ -2250,8 +2250,8 @@ STR_2245    :October
 STR_2246    :November
 STR_2247    :December
 STR_2248    :Can't demolish ride/attraction...
-STR_2249    :{BABYBLUE}New ride/attraction now available:-{NEWLINE}{STRINGID}
-STR_2250    :{BABYBLUE}New scenery/themeing now available:-{NEWLINE}{STRINGID}
+STR_2249    :{BABYBLUE}New ride/attraction now available:{NEWLINE}{STRINGID}
+STR_2250    :{BABYBLUE}New scenery/themeing now available:{NEWLINE}{STRINGID}
 STR_2251    :Can only be built on paths!
 STR_2252    :Can only be built across paths!
 STR_2253    :Transport Rides
@@ -2789,14 +2789,14 @@ STR_2781    :{STRINGID}:{MOVE_X}{195}{STRINGID}{STRINGID}
 STR_2782    :SHIFT + 
 STR_2783    :CTRL + 
 STR_2784    :Change keyboard shortcut
-STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:-{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
+STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
 STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
 STR_2787    :{WINDOW_COLOUR_2}Park value: {BLACK}{CURRENCY}
 STR_2788    :{WINDOW_COLOUR_2}Congratulations !{NEWLINE}{BLACK}You achieved your objective with a company value of {CURRENCY} !
 STR_2789    :{WINDOW_COLOUR_2}You have failed your objective !
 STR_2790    :Enter name into scenario chart
 STR_2791    :Enter name
-STR_2792    :Please enter your name for the scenario chart:-
+STR_2792    :Please enter your name for the scenario chart:
 STR_2793    :{SMALLFONT}(Completed by {STRINGID})
 STR_2794    :{WINDOW_COLOUR_2}Completed by: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} with a company value of: {BLACK}{CURRENCY}
 STR_2795    :Sort
@@ -2982,12 +2982,12 @@ STR_2974    :Alternative colour scheme 3
 STR_2975    :{SMALLFONT}{BLACK}Select which colour scheme to change, or paint ride with
 STR_2976    :{SMALLFONT}{BLACK}Paint an individual area of this ride using the selected colour scheme
 STR_2977    :Staff member name
-STR_2978    :Enter new name for this member of staff:-
+STR_2978    :Enter new name for this member of staff:
 STR_2979    :Can't name staff member...
 STR_2980    :Too many banners in game
 STR_2981    :{RED}No entry - - 
 STR_2982    :Banner text
-STR_2983    :Enter new text for this banner:-
+STR_2983    :Enter new text for this banner:
 STR_2984    :Can't set new text for banner...
 STR_2985    :Banner
 STR_2986    :{SMALLFONT}{BLACK}Change text on banner
@@ -2997,7 +2997,7 @@ STR_2989    :{SMALLFONT}{BLACK}Select main colour
 STR_2990    :{SMALLFONT}{BLACK}Select text colour
 STR_2991    :Sign
 STR_2992    :Sign text
-STR_2993    :Enter new text for this sign:-
+STR_2993    :Enter new text for this sign:
 STR_2994    :{SMALLFONT}{BLACK}Change text on sign
 STR_2995    :{SMALLFONT}{BLACK}Demolish this sign
 STR_2996    :{BLACK}ABC

--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3318,9 +3318,9 @@ STR_3310    :{WINDOW_COLOUR_2}{LENGTH}
 STR_3311    :{WINDOW_COLOUR_2}{COMMA2DP32}
 STR_3312    :{WINDOW_COLOUR_2}Rides/attractions under a preservation order:
 STR_3313    :Scenario Name
-STR_3314    :Enter name for scenario:-
+STR_3314    :Enter name for scenario:
 STR_3315    :Park/Scenario Details
-STR_3316    :Enter description of this scenario:-
+STR_3316    :Enter description of this scenario:
 STR_3317    :No details yet
 STR_3318    :{SMALLFONT}{BLACK}Select which group this scenario appears in
 STR_3319    :{WINDOW_COLOUR_2}Scenario Group:
@@ -3355,7 +3355,7 @@ STR_3347    :Ride is too large, contains too many elements, or scenery is too sp
 STR_3348    :Rename
 STR_3349    :Delete
 STR_3350    :Track design name
-STR_3351    :Enter new name for this track design:-
+STR_3351    :Enter new name for this track design:
 STR_3352    :Can't rename track design...
 STR_3353    :New name contains invalid characters
 STR_3354    :Another file exists with this name, or file is write-protected

--- a/data/language/english_us.txt
+++ b/data/language/english_us.txt
@@ -857,7 +857,7 @@ STR_0852    :{WINDOW_COLOUR_2}Graphics by Simon Foster
 STR_0853    :{WINDOW_COLOUR_2}Sound and music by Allister Brimble
 STR_0854    :{WINDOW_COLOUR_2}Additional sounds recorded by David Ellis
 STR_0855    :{WINDOW_COLOUR_2}Representation by Jacqui Lyons at Marjacq Ltd.
-STR_0856    :{WINDOW_COLOUR_2}Thanks to:-
+STR_0856    :{WINDOW_COLOUR_2}Thanks to:
 STR_0857    :{WINDOW_COLOUR_2}Peter James Adcock, Joe Booth, and John Wardley
 STR_0858    :{WINDOW_COLOUR_2}
 STR_0859    :{WINDOW_COLOUR_2}
@@ -1059,7 +1059,7 @@ STR_1054    :{SMALLFONT}{BLACK}Name ride/attraction
 STR_1055    :{SMALLFONT}{BLACK}Name person
 STR_1056    :{SMALLFONT}{BLACK}Name staff member
 STR_1057    :Ride/attraction name
-STR_1058    :Enter new name for this ride/attraction:-
+STR_1058    :Enter new name for this ride/attraction:
 STR_1059    :Can't rename ride/attraction...
 STR_1060    :Invalid ride/attraction name
 STR_1061    :Normal mode
@@ -1454,7 +1454,7 @@ STR_1449    :{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1450    :{INLINE_SPRITE}{09}{20}{00}{00}{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1451    :{STRINGID}{NEWLINE}({STRINGID})
 STR_1452    :Guest's name
-STR_1453    :Enter name for this guest:-
+STR_1453    :Enter name for this guest:
 STR_1454    :Can't name guest...
 STR_1455    :Invalid name for guest
 STR_1456    :{WINDOW_COLOUR_2}Cash spent: {BLACK}{CURRENCY2DP}
@@ -1720,7 +1720,7 @@ STR_1715    :{INLINE_SPRITE}{250}{19}{00}{00}{WINDOW_COLOUR_2}Mow grass
 STR_1716    :Invalid name for park
 STR_1717    :Can't rename park...
 STR_1718    :Park Name
-STR_1719    :Enter name for park:-
+STR_1719    :Enter name for park:
 STR_1720    :{SMALLFONT}{BLACK}Name park
 STR_1721    :Park closed
 STR_1722    :Park open
@@ -1894,7 +1894,7 @@ STR_1889    :{WINDOW_COLOUR_2}Down-Time: {MOVE_X}{255}{BLACK}{COMMA16}%
 STR_1890    :{SMALLFONT}{BLACK}Select how often a mechanic should check this ride
 STR_1891    :No {STRINGID} in park yet!
 STR_1892    :RollerCoaster Tycoon 2
-STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:-
+STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:
 STR_1894    :{WINDOW_COLOUR_2}{STRINGID} sold: {BLACK}{COMMA32}
 STR_1895    :{SMALLFONT}{BLACK}Build new ride/attraction
 STR_1896    :{WINDOW_COLOUR_2}Expenditure/Income
@@ -2250,8 +2250,8 @@ STR_2245    :October
 STR_2246    :November
 STR_2247    :December
 STR_2248    :Can't demolish ride/attraction...
-STR_2249    :{BABYBLUE}New ride/attraction now available:-{NEWLINE}{STRINGID}
-STR_2250    :{BABYBLUE}New scenery/themeing now available:-{NEWLINE}{STRINGID}
+STR_2249    :{BABYBLUE}New ride/attraction now available:{NEWLINE}{STRINGID}
+STR_2250    :{BABYBLUE}New scenery/themeing now available:{NEWLINE}{STRINGID}
 STR_2251    :Can only be built on paths!
 STR_2252    :Can only be built across paths!
 STR_2253    :Transport Rides
@@ -2788,14 +2788,14 @@ STR_2781    :{STRINGID}:{MOVE_X}{195}{STRINGID}{STRINGID}
 STR_2782    :SHIFT + 
 STR_2783    :CTRL + 
 STR_2784    :Change keyboard shortcut
-STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:-{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
+STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
 STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
 STR_2787    :{WINDOW_COLOUR_2}Park value: {BLACK}{CURRENCY}
 STR_2788    :{WINDOW_COLOUR_2}Congratulations !{NEWLINE}{BLACK}You achieved your objective with a company value of {CURRENCY} !
 STR_2789    :{WINDOW_COLOUR_2}You have failed your objective !
 STR_2790    :Enter name into scenario chart
 STR_2791    :Enter name
-STR_2792    :Please enter your name for the scenario chart:-
+STR_2792    :Please enter your name for the scenario chart:
 STR_2793    :{SMALLFONT}(Completed by {STRINGID})
 STR_2794    :{WINDOW_COLOUR_2}Completed by: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} with a company value of: {BLACK}{CURRENCY}
 STR_2795    :Sort
@@ -2981,12 +2981,12 @@ STR_2974    :Alternative color scheme 3
 STR_2975    :{SMALLFONT}{BLACK}Select which color scheme to change, or paint ride with
 STR_2976    :{SMALLFONT}{BLACK}Paint an individual area of this ride using the selected color scheme
 STR_2977    :Staff member name
-STR_2978    :Enter new name for this member of staff:-
+STR_2978    :Enter new name for this member of staff:
 STR_2979    :Can't name staff member...
 STR_2980    :Too many banners in game
 STR_2981    :{RED}No entry - - 
 STR_2982    :Banner text
-STR_2983    :Enter new text for this banner:-
+STR_2983    :Enter new text for this banner:
 STR_2984    :Can't set new text for banner...
 STR_2985    :Banner
 STR_2986    :{SMALLFONT}{BLACK}Change text on banner
@@ -2996,7 +2996,7 @@ STR_2989    :{SMALLFONT}{BLACK}Select main color
 STR_2990    :{SMALLFONT}{BLACK}Select text color
 STR_2991    :Sign
 STR_2992    :Sign text
-STR_2993    :Enter new text for this sign:-
+STR_2993    :Enter new text for this sign:
 STR_2994    :{SMALLFONT}{BLACK}Change text on sign
 STR_2995    :{SMALLFONT}{BLACK}Demolish this sign
 STR_2996    :{BLACK}ABC
@@ -3317,9 +3317,9 @@ STR_3310    :{WINDOW_COLOUR_2}{LENGTH}
 STR_3311    :{WINDOW_COLOUR_2}{COMMA2DP32}
 STR_3312    :{WINDOW_COLOUR_2}Rides/attractions under a preservation order:
 STR_3313    :Scenario Name
-STR_3314    :Enter name for scenario:-
+STR_3314    :Enter name for scenario:
 STR_3315    :Park/Scenario Details
-STR_3316    :Enter description of this scenario:-
+STR_3316    :Enter description of this scenario:
 STR_3317    :No details yet
 STR_3318    :{SMALLFONT}{BLACK}Select which group this scenario appears in
 STR_3319    :{WINDOW_COLOUR_2}Scenario Group:
@@ -3354,7 +3354,7 @@ STR_3347    :Ride is too large, contains too many elements, or scenery is too sp
 STR_3348    :Rename
 STR_3349    :Delete
 STR_3350    :Track design name
-STR_3351    :Enter new name for this track design:-
+STR_3351    :Enter new name for this track design:
 STR_3352    :Can't rename track design...
 STR_3353    :New name contains invalid characters
 STR_3354    :Another file exists with this name, or file is write-protected

--- a/data/language/french.txt
+++ b/data/language/french.txt
@@ -857,7 +857,7 @@ STR_0852    :{WINDOW_COLOUR_2}Graphismes : Simon Foster
 STR_0853    :{WINDOW_COLOUR_2}Son et musique : Allister Brimble
 STR_0854    :{WINDOW_COLOUR_2}Enregistrement sons additionnels : David Ellis
 STR_0855    :{WINDOW_COLOUR_2}Représentation :Jacqui Lyons, Marjacq Ltd.
-STR_0856    :{WINDOW_COLOUR_2}Remerciements:-
+STR_0856    :{WINDOW_COLOUR_2}Remerciements:
 STR_0857    :{WINDOW_COLOUR_2}Peter James Adcock, Joe Booth, and John Wardley
 STR_0858    :{WINDOW_COLOUR_2}
 STR_0859    :{WINDOW_COLOUR_2}
@@ -1059,7 +1059,7 @@ STR_1054    :{SMALLFONT}{BLACK}Name ride/attraction
 STR_1055    :{SMALLFONT}{BLACK}Name person
 STR_1056    :{SMALLFONT}{BLACK}Name staff member
 STR_1057    :Ride/attraction name
-STR_1058    :Enter new name for this ride/attraction:-
+STR_1058    :Enter new name for this ride/attraction:
 STR_1059    :Can't rename ride/attraction...
 STR_1060    :Invalid ride/attraction name
 STR_1061    :Normal mode
@@ -1454,7 +1454,7 @@ STR_1449    :{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1450    :{INLINE_SPRITE}{09}{20}{00}{00}{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1451    :{STRINGID}{NEWLINE}({STRINGID})
 STR_1452    :Guest's name
-STR_1453    :Enter name for this guest:-
+STR_1453    :Enter name for this guest:
 STR_1454    :Can't name guest...
 STR_1455    :Invalid name for guest
 STR_1456    :{WINDOW_COLOUR_2}Cash spent: {BLACK}{CURRENCY2DP}
@@ -1720,7 +1720,7 @@ STR_1715    :{INLINE_SPRITE}{250}{19}{00}{00}{WINDOW_COLOUR_2}Mow grass
 STR_1716    :Nom du parc non valide
 STR_1717    :Impossible de renommer le parc...
 STR_1718    :Nom dur parc
-STR_1719    :Saisir nom du parc:-
+STR_1719    :Saisir nom du parc:
 STR_1720    :{SMALLFONT}{BLACK}Name park
 STR_1721    :Parc fermé
 STR_1722    :Parc ouvert
@@ -1894,7 +1894,7 @@ STR_1889    :{WINDOW_COLOUR_2}Down-Time: {MOVE_X}{255}{BLACK}{COMMA16}%
 STR_1890    :{SMALLFONT}{BLACK}Select how often a mechanic should check this ride
 STR_1891    :No {STRINGID} in park yet!
 STR_1892    :RollerCoaster Tycoon 2
-STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:-
+STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:
 STR_1894    :{WINDOW_COLOUR_2}{STRINGID} sold: {BLACK}{COMMA32}
 STR_1895    :{SMALLFONT}{BLACK}Build new ride/attraction
 STR_1896    :{WINDOW_COLOUR_2}Dépenses/Revenus
@@ -2250,8 +2250,8 @@ STR_2245    :Octobre
 STR_2246    :Novembre
 STR_2247    :Décembre
 STR_2248    :Can't demolish ride/attraction...
-STR_2249    :{BABYBLUE}New ride/attraction now available:-{NEWLINE}{STRINGID}
-STR_2250    :{BABYBLUE}New scenery/themeing now available:-{NEWLINE}{STRINGID}
+STR_2249    :{BABYBLUE}New ride/attraction now available:{NEWLINE}{STRINGID}
+STR_2250    :{BABYBLUE}New scenery/themeing now available:{NEWLINE}{STRINGID}
 STR_2251    :Can only be built on paths!
 STR_2252    :Can only be built across paths!
 STR_2253    :Attractions de transport
@@ -2788,14 +2788,14 @@ STR_2781    :{STRINGID}:{MOVE_X}{195}{STRINGID}{STRINGID}
 STR_2782    :SHIFT + 
 STR_2783    :CTRL + 
 STR_2784    :Change keyboard shortcut
-STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:-{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
+STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
 STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
 STR_2787    :{WINDOW_COLOUR_2}Park value: {BLACK}{CURRENCY}
 STR_2788    :{WINDOW_COLOUR_2}Congratulations !{NEWLINE}{BLACK}You achieved your objective with a company value of {CURRENCY} !
 STR_2789    :{WINDOW_COLOUR_2}You have failed your objective !
 STR_2790    :Enter name into scenario chart
 STR_2791    :Enter name
-STR_2792    :Please enter your name for the scenario chart:-
+STR_2792    :Please enter your name for the scenario chart:
 STR_2793    :{SMALLFONT}(Completed by {STRINGID})
 STR_2794    :{WINDOW_COLOUR_2}Completed by: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} with a company value of: {BLACK}{CURRENCY}
 STR_2795    :Sort
@@ -2981,12 +2981,12 @@ STR_2974    :Alternative color scheme 3
 STR_2975    :{SMALLFONT}{BLACK}Select which color scheme to change, or paint ride with
 STR_2976    :{SMALLFONT}{BLACK}Paint an individual area of this ride using the selected color scheme
 STR_2977    :Staff member name
-STR_2978    :Enter new name for this member of staff:-
+STR_2978    :Enter new name for this member of staff:
 STR_2979    :Can't name staff member...
 STR_2980    :Too many banners in game
 STR_2981    :{RED}No entry - - 
 STR_2982    :Banner text
-STR_2983    :Enter new text for this banner:-
+STR_2983    :Enter new text for this banner:
 STR_2984    :Can't set new text for banner...
 STR_2985    :Banner
 STR_2986    :{SMALLFONT}{BLACK}Change text on banner
@@ -2996,7 +2996,7 @@ STR_2989    :{SMALLFONT}{BLACK}Select main color
 STR_2990    :{SMALLFONT}{BLACK}Select text color
 STR_2991    :Sign
 STR_2992    :Sign text
-STR_2993    :Enter new text for this sign:-
+STR_2993    :Enter new text for this sign:
 STR_2994    :{SMALLFONT}{BLACK}Change text on sign
 STR_2995    :{SMALLFONT}{BLACK}Demolish this sign
 STR_2996    :{BLACK}ABC
@@ -3317,9 +3317,9 @@ STR_3310    :{WINDOW_COLOUR_2}{LENGTH}
 STR_3311    :{WINDOW_COLOUR_2}{COMMA2DP32}
 STR_3312    :{WINDOW_COLOUR_2}Rides/attractions under a preservation order:
 STR_3313    :Scenario Name
-STR_3314    :Enter name for scenario:-
+STR_3314    :Enter name for scenario:
 STR_3315    :Park/Scenario Details
-STR_3316    :Décrire ce scénario:-
+STR_3316    :Décrire ce scénario:
 STR_3317    :Pas de détails
 STR_3318    :{SMALLFONT}{BLACK}Select which group this scenario appears in
 STR_3319    :{WINDOW_COLOUR_2}Scenario Group:
@@ -3354,7 +3354,7 @@ STR_3347    :Ride is too large, contains too many elements, or scenery is too sp
 STR_3348    :Rename
 STR_3349    :Delete
 STR_3350    :Track design name
-STR_3351    :Enter new name for this track design:-
+STR_3351    :Enter new name for this track design:
 STR_3352    :Can't rename track design...
 STR_3353    :New name contains invalid characters
 STR_3354    :Another file exists with this name, or file is write-protected

--- a/data/language/hungarian.txt
+++ b/data/language/hungarian.txt
@@ -857,7 +857,7 @@ STR_0852    :{WINDOW_COLOUR_2}Graphics by Simon Foster
 STR_0853    :{WINDOW_COLOUR_2}Sound and music by Allister Brimble
 STR_0854    :{WINDOW_COLOUR_2}Additional sounds recorded by David Ellis
 STR_0855    :{WINDOW_COLOUR_2}Representation by Jacqui Lyons at Marjacq Ltd.
-STR_0856    :{WINDOW_COLOUR_2}Thanks to:-
+STR_0856    :{WINDOW_COLOUR_2}Thanks to:
 STR_0857    :{WINDOW_COLOUR_2}Peter James Adcock, Joe Booth, and John Wardley
 STR_0858    :{WINDOW_COLOUR_2}
 STR_0859    :{WINDOW_COLOUR_2}
@@ -1059,7 +1059,7 @@ STR_1054    :{SMALLFONT}{BLACK}Name ride/attraction
 STR_1055    :{SMALLFONT}{BLACK}Name person
 STR_1056    :{SMALLFONT}{BLACK}Name staff member
 STR_1057    :Ride/attraction name
-STR_1058    :Enter new name for this ride/attraction:-
+STR_1058    :Enter new name for this ride/attraction:
 STR_1059    :Can't rename ride/attraction...
 STR_1060    :Invalid ride/attraction name
 STR_1061    :Normal mode
@@ -1454,7 +1454,7 @@ STR_1449    :{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1450    :{INLINE_SPRITE}{09}{20}{00}{00}{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1451    :{STRINGID}{NEWLINE}({STRINGID})
 STR_1452    :Vendég neve
-STR_1453    :Add meg a vendég nevét:-
+STR_1453    :Add meg a vendég nevét:
 STR_1454    :Can't name guest...
 STR_1455    :Invalid name for guest
 STR_1456    :{WINDOW_COLOUR_2}Cash spent: {BLACK}{CURRENCY2DP}
@@ -1720,7 +1720,7 @@ STR_1715    :{INLINE_SPRITE}{250}{19}{00}{00}{WINDOW_COLOUR_2}Fűnyírás
 STR_1716    :Invalid name for park
 STR_1717    :Can't rename park...
 STR_1718    :Park Name
-STR_1719    :Enter name for park:-
+STR_1719    :Enter name for park:
 STR_1720    :{SMALLFONT}{BLACK}Name park
 STR_1721    :Park closed
 STR_1722    :Park open
@@ -1894,7 +1894,7 @@ STR_1889    :{WINDOW_COLOUR_2}Down-Time: {MOVE_X}{255}{BLACK}{COMMA16}%
 STR_1890    :{SMALLFONT}{BLACK}Select how often a mechanic should check this ride
 STR_1891    :No {STRINGID} in park yet!
 STR_1892    :RollerCoaster Tycoon 2
-STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:-
+STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:
 STR_1894    :{WINDOW_COLOUR_2}{STRINGID} sold: {BLACK}{COMMA32}
 STR_1895    :{SMALLFONT}{BLACK}Build new ride/attraction
 STR_1896    :{WINDOW_COLOUR_2}Expenditure/Income
@@ -2250,8 +2250,8 @@ STR_2245    :Október
 STR_2246    :November
 STR_2247    :December
 STR_2248    :Can't demolish ride/attraction...
-STR_2249    :{BABYBLUE}New ride/attraction now available:-{NEWLINE}{STRINGID}
-STR_2250    :{BABYBLUE}New scenery/themeing now available:-{NEWLINE}{STRINGID}
+STR_2249    :{BABYBLUE}New ride/attraction now available:{NEWLINE}{STRINGID}
+STR_2250    :{BABYBLUE}New scenery/themeing now available:{NEWLINE}{STRINGID}
 STR_2251    :Can only be built on paths!
 STR_2252    :Can only be built across paths!
 STR_2253    :Transport Rides
@@ -2788,14 +2788,14 @@ STR_2781    :{STRINGID}:{MOVE_X}{195}{STRINGID}{STRINGID}
 STR_2782    :SHIFT + 
 STR_2783    :CTRL + 
 STR_2784    :Change keyboard shortcut
-STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:-{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
+STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
 STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
 STR_2787    :{WINDOW_COLOUR_2}Park value: {BLACK}{CURRENCY}
 STR_2788    :{WINDOW_COLOUR_2}Congratulations !{NEWLINE}{BLACK}You achieved your objective with a company value of {CURRENCY} !
 STR_2789    :{WINDOW_COLOUR_2}You have failed your objective !
 STR_2790    :Enter name into scenario chart
 STR_2791    :Enter name
-STR_2792    :Please enter your name for the scenario chart:-
+STR_2792    :Please enter your name for the scenario chart:
 STR_2793    :{SMALLFONT}(Completed by {STRINGID})
 STR_2794    :{WINDOW_COLOUR_2}Completed by: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} with a company value of: {BLACK}{CURRENCY}
 STR_2795    :Sort
@@ -2981,12 +2981,12 @@ STR_2974    :Alternative color scheme 3
 STR_2975    :{SMALLFONT}{BLACK}Select which color scheme to change, or paint ride with
 STR_2976    :{SMALLFONT}{BLACK}Paint an individual area of this ride using the selected color scheme
 STR_2977    :Staff member name
-STR_2978    :Enter new name for this member of staff:-
+STR_2978    :Enter new name for this member of staff:
 STR_2979    :Can't name staff member...
 STR_2980    :Too many banners in game
 STR_2981    :{RED}No entry - - 
 STR_2982    :Banner text
-STR_2983    :Enter new text for this banner:-
+STR_2983    :Enter new text for this banner:
 STR_2984    :Can't set new text for banner...
 STR_2985    :Banner
 STR_2986    :{SMALLFONT}{BLACK}Change text on banner
@@ -2996,7 +2996,7 @@ STR_2989    :{SMALLFONT}{BLACK}Select main color
 STR_2990    :{SMALLFONT}{BLACK}Select text color
 STR_2991    :Sign
 STR_2992    :Sign text
-STR_2993    :Enter new text for this sign:-
+STR_2993    :Enter new text for this sign:
 STR_2994    :{SMALLFONT}{BLACK}Change text on sign
 STR_2995    :{SMALLFONT}{BLACK}Demolish this sign
 STR_2996    :{BLACK}ABC
@@ -3317,9 +3317,9 @@ STR_3310    :{WINDOW_COLOUR_2}{LENGTH}
 STR_3311    :{WINDOW_COLOUR_2}{COMMA2DP32}
 STR_3312    :{WINDOW_COLOUR_2}Rides/attractions under a preservation order:
 STR_3313    :Scenario Name
-STR_3314    :Enter name for scenario:-
+STR_3314    :Enter name for scenario:
 STR_3315    :Park/Scenario Details
-STR_3316    :Enter description of this scenario:-
+STR_3316    :Enter description of this scenario:
 STR_3317    :No details yet
 STR_3318    :{SMALLFONT}{BLACK}Select which group this scenario appears in
 STR_3319    :{WINDOW_COLOUR_2}Scenario Group:
@@ -3354,7 +3354,7 @@ STR_3347    :Ride is too large, contains too many elements, or scenery is too sp
 STR_3348    :Rename
 STR_3349    :Delete
 STR_3350    :Track design name
-STR_3351    :Enter new name for this track design:-
+STR_3351    :Enter new name for this track design:
 STR_3352    :Can't rename track design...
 STR_3353    :New name contains invalid characters
 STR_3354    :Another file exists with this name, or file is write-protected

--- a/data/language/polish.txt
+++ b/data/language/polish.txt
@@ -859,7 +859,7 @@ STR_0852    :{WINDOW_COLOUR_2}Graphics by Simon Foster
 STR_0853    :{WINDOW_COLOUR_2}Sound and music by Allister Brimble
 STR_0854    :{WINDOW_COLOUR_2}Additional sounds recorded by David Ellis
 STR_0855    :{WINDOW_COLOUR_2}Representation by Jacqui Lyons at Marjacq Ltd.
-STR_0856    :{WINDOW_COLOUR_2}Thanks to:-
+STR_0856    :{WINDOW_COLOUR_2}Thanks to:
 STR_0857    :{WINDOW_COLOUR_2}Peter James Adcock, Joe Booth, and John Wardley
 STR_0858    :{WINDOW_COLOUR_2}
 STR_0859    :{WINDOW_COLOUR_2}
@@ -1065,7 +1065,7 @@ STR_1054    :{SMALLFONT}{BLACK}Name ride/attraction
 STR_1055    :{SMALLFONT}{BLACK}Name person
 STR_1056    :{SMALLFONT}{BLACK}Name staff member
 STR_1057    :Ride/attraction name
-STR_1058    :Enter new name for this ride/attraction:-
+STR_1058    :Enter new name for this ride/attraction:
 STR_1059    :Can't rename ride/attraction...
 STR_1060    :Invalid ride/attraction name
 STR_1061    :Normal mode
@@ -1464,7 +1464,7 @@ STR_1449    :{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1450    :{INLINE_SPRITE}{09}{20}{00}{00}{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1451    :{STRINGID}{NEWLINE}({STRINGID})
 STR_1452    :Imię gościa
-STR_1453    :Nowe imię dla gościa:-
+STR_1453    :Nowe imię dla gościa:
 STR_1454    :Nie można tak nazwać gościa...
 STR_1455    :Niewłaściwe imię dla gościa
 STR_1456    :{WINDOW_COLOUR_2}Wydał: {BLACK}{CURRENCY2DP}
@@ -1907,7 +1907,7 @@ STR_1889    :{WINDOW_COLOUR_2}Down-Time: {MOVE_X}{255}{BLACK}{COMMA16}%
 STR_1890    :{SMALLFONT}{BLACK}Select how often a mechanic should check this ride
 STR_1891    :No {STRINGID} in park yet!
 STR_1892    :RollerCoaster Tycoon 2
-STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:-
+STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:
 STR_1894    :{WINDOW_COLOUR_2}{STRINGID} sold: {BLACK}{COMMA32}
 STR_1895    :{SMALLFONT}{BLACK}Build new ride/attraction
 # ------------------------------------------ Polish start
@@ -2266,8 +2266,8 @@ STR_2245    :Października
 STR_2246    :Listopada
 STR_2247    :Grudnia
 STR_2248    :Nie można zburzyć atrakcji...
-STR_2249    :{BABYBLUE}Nowa atrakcja dostępna:-{NEWLINE}{STRINGID}
-STR_2250    :{BABYBLUE}Nowa sceneria dostępna:-{NEWLINE}{STRINGID}
+STR_2249    :{BABYBLUE}Nowa atrakcja dostępna:{NEWLINE}{STRINGID}
+STR_2250    :{BABYBLUE}Nowa sceneria dostępna:{NEWLINE}{STRINGID}
 STR_2251    :Można budować tylko na chodnikach!
 STR_2252    :Można budować tylko w poprzek chodników!
 STR_2253    :Transport
@@ -2811,14 +2811,14 @@ STR_2781    :{STRINGID}:{MOVE_X}{195}{STRINGID}{STRINGID}
 STR_2782    :SHIFT + 
 STR_2783    :CTRL + 
 STR_2784    :Change keyboard shortcut
-STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:-{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
+STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
 STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
 STR_2787    :{WINDOW_COLOUR_2}Park value: {BLACK}{CURRENCY}
 STR_2788    :{WINDOW_COLOUR_2}Congratulations !{NEWLINE}{BLACK}You achieved your objective with a company value of {CURRENCY} !
 STR_2789    :{WINDOW_COLOUR_2}You have failed your objective !
 STR_2790    :Enter name into scenario chart
 STR_2791    :Enter name
-STR_2792    :Please enter your name for the scenario chart:-
+STR_2792    :Please enter your name for the scenario chart:
 STR_2793    :{SMALLFONT}(Completed by {STRINGID})
 STR_2794    :{WINDOW_COLOUR_2}Completed by: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} with a company value of: {BLACK}{CURRENCY}
 STR_2795    :Sort
@@ -3006,12 +3006,12 @@ STR_2974    :Alternative color scheme 3
 STR_2975    :{SMALLFONT}{BLACK}Select which color scheme to change, or paint ride with
 STR_2976    :{SMALLFONT}{BLACK}Paint an individual area of this ride using the selected color scheme
 STR_2977    :Staff member name
-STR_2978    :Enter new name for this member of staff:-
+STR_2978    :Enter new name for this member of staff:
 STR_2979    :Can't name staff member...
 STR_2980    :Too many banners in game
 STR_2981    :{RED}No entry - - 
 STR_2982    :Banner text
-STR_2983    :Enter new text for this banner:-
+STR_2983    :Enter new text for this banner:
 STR_2984    :Can't set new text for banner...
 STR_2985    :Banner
 STR_2986    :{SMALLFONT}{BLACK}Change text on banner
@@ -3021,7 +3021,7 @@ STR_2989    :{SMALLFONT}{BLACK}Select main color
 STR_2990    :{SMALLFONT}{BLACK}Select text color
 STR_2991    :Sign
 STR_2992    :Sign text
-STR_2993    :Enter new text for this sign:-
+STR_2993    :Enter new text for this sign:
 STR_2994    :{SMALLFONT}{BLACK}Change text on sign
 STR_2995    :{SMALLFONT}{BLACK}Demolish this sign
 STR_2996    :{BLACK}ABC
@@ -3346,9 +3346,9 @@ STR_3310    :{WINDOW_COLOUR_2}{LENGTH}
 STR_3311    :{WINDOW_COLOUR_2}{COMMA2DP32}
 STR_3312    :{WINDOW_COLOUR_2}Rides/attractions under a preservation order:
 STR_3313    :Scenario Name
-STR_3314    :Enter name for scenario:-
+STR_3314    :Enter name for scenario:
 STR_3315    :Park/Scenario Details
-STR_3316    :Enter description of this scenario:-
+STR_3316    :Enter description of this scenario:
 STR_3317    :No details yet
 STR_3318    :{SMALLFONT}{BLACK}Select which group this scenario appears in
 STR_3319    :{WINDOW_COLOUR_2}Scenario Group:
@@ -3385,7 +3385,7 @@ STR_3347    :Ride is too large, contains too many elements, or scenery is too sp
 STR_3348    :Rename
 STR_3349    :Delete
 STR_3350    :Track design name
-STR_3351    :Enter new name for this track design:-
+STR_3351    :Enter new name for this track design:
 STR_3352    :Can't rename track design...
 STR_3353    :New name contains invalid characters
 STR_3354    :Another file exists with this name, or file is write-protected

--- a/data/language/spanish_sp.txt
+++ b/data/language/spanish_sp.txt
@@ -857,7 +857,7 @@ STR_0852    :{WINDOW_COLOUR_2}Graphics by Simon Foster
 STR_0853    :{WINDOW_COLOUR_2}Sound and music by Allister Brimble
 STR_0854    :{WINDOW_COLOUR_2}Additional sounds recorded by David Ellis
 STR_0855    :{WINDOW_COLOUR_2}Representation by Jacqui Lyons at Marjacq Ltd.
-STR_0856    :{WINDOW_COLOUR_2}Thanks to:-
+STR_0856    :{WINDOW_COLOUR_2}Thanks to:
 STR_0857    :{WINDOW_COLOUR_2}Peter James Adcock, Joe Booth, and John Wardley
 STR_0858    :{WINDOW_COLOUR_2}
 STR_0859    :{WINDOW_COLOUR_2}
@@ -1059,7 +1059,7 @@ STR_1054    :{SMALLFONT}{BLACK}Name ride/attraction
 STR_1055    :{SMALLFONT}{BLACK}Name person
 STR_1056    :{SMALLFONT}{BLACK}Name staff member
 STR_1057    :Ride/attraction name
-STR_1058    :Enter new name for this ride/attraction:-
+STR_1058    :Enter new name for this ride/attraction:
 STR_1059    :Can't rename ride/attraction...
 STR_1060    :Invalid ride/attraction name
 STR_1061    :Normal mode
@@ -1454,7 +1454,7 @@ STR_1449    :{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1450    :{INLINE_SPRITE}{09}{20}{00}{00}{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1451    :{STRINGID}{NEWLINE}({STRINGID})
 STR_1452    :Visitante's name
-STR_1453    :Enter name for this guest:-
+STR_1453    :Enter name for this guest:
 STR_1454    :Can't name guest...
 STR_1455    :Invalid name for guest
 STR_1456    :{WINDOW_COLOUR_2}Cash spent: {BLACK}{CURRENCY2DP}
@@ -1720,7 +1720,7 @@ STR_1715    :{INLINE_SPRITE}{250}{19}{00}{00}{WINDOW_COLOUR_2}Mow grass
 STR_1716    :Invalid name for park
 STR_1717    :Can't rename park...
 STR_1718    :Park Name
-STR_1719    :Enter name for park:-
+STR_1719    :Enter name for park:
 STR_1720    :{SMALLFONT}{BLACK}Name park
 STR_1721    :Park closed
 STR_1722    :Park open
@@ -1894,7 +1894,7 @@ STR_1889    :{WINDOW_COLOUR_2}Down-Time: {MOVE_X}{255}{BLACK}{COMMA16}%
 STR_1890    :{SMALLFONT}{BLACK}Select how often a mechanic should check this ride
 STR_1891    :No {STRINGID} in park yet!
 STR_1892    :RollerCoaster Tycoon 2
-STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:-
+STR_1893    :Please insert your RollerCoaster Tycoon 2 CD in the following drive:
 STR_1894    :{WINDOW_COLOUR_2}{STRINGID} sold: {BLACK}{COMMA32}
 STR_1895    :{SMALLFONT}{BLACK}Build new ride/attraction
 STR_1896    :{WINDOW_COLOUR_2}Expenditure/Income
@@ -2250,8 +2250,8 @@ STR_2245    :October
 STR_2246    :November
 STR_2247    :December
 STR_2248    :Can't demolish ride/attraction...
-STR_2249    :{BABYBLUE}New ride/attraction now available:-{NEWLINE}{STRINGID}
-STR_2250    :{BABYBLUE}New scenery/themeing now available:-{NEWLINE}{STRINGID}
+STR_2249    :{BABYBLUE}New ride/attraction now available:{NEWLINE}{STRINGID}
+STR_2250    :{BABYBLUE}New scenery/themeing now available:{NEWLINE}{STRINGID}
 STR_2251    :Can only be built on paths!
 STR_2252    :Can only be built across paths!
 STR_2253    :Transport Rides
@@ -2788,14 +2788,14 @@ STR_2781    :{STRINGID}:{MOVE_X}{195}{STRINGID}{STRINGID}
 STR_2782    :SHIFT + 
 STR_2783    :CTRL + 
 STR_2784    :Change keyboard shortcut
-STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:-{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
+STR_2785    :{WINDOW_COLOUR_2}Press new shortcut key for:{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
 STR_2786    :{SMALLFONT}{BLACK}Click on shortcut description to select new key
 STR_2787    :{WINDOW_COLOUR_2}Park value: {BLACK}{CURRENCY}
 STR_2788    :{WINDOW_COLOUR_2}Congratulations !{NEWLINE}{BLACK}You achieved your objective with a company value of {CURRENCY} !
 STR_2789    :{WINDOW_COLOUR_2}You have failed your objective !
 STR_2790    :Enter name into scenario chart
 STR_2791    :Enter name
-STR_2792    :Please enter your name for the scenario chart:-
+STR_2792    :Please enter your name for the scenario chart:
 STR_2793    :{SMALLFONT}(Completed by {STRINGID})
 STR_2794    :{WINDOW_COLOUR_2}Completed by: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} with a company value of: {BLACK}{CURRENCY}
 STR_2795    :Sort
@@ -2981,12 +2981,12 @@ STR_2974    :Alternative colour scheme 3
 STR_2975    :{SMALLFONT}{BLACK}Select which colour scheme to change, or paint ride with
 STR_2976    :{SMALLFONT}{BLACK}Paint an individual area of this ride using the selected colour scheme
 STR_2977    :Staff member name
-STR_2978    :Enter new name for this member of staff:-
+STR_2978    :Enter new name for this member of staff:
 STR_2979    :Can't name staff member...
 STR_2980    :Too many banners in game
 STR_2981    :{RED}No entry - - 
 STR_2982    :Banner text
-STR_2983    :Enter new text for this banner:-
+STR_2983    :Enter new text for this banner:
 STR_2984    :Can't set new text for banner...
 STR_2985    :Banner
 STR_2986    :{SMALLFONT}{BLACK}Change text on banner
@@ -2996,7 +2996,7 @@ STR_2989    :{SMALLFONT}{BLACK}Select main colour
 STR_2990    :{SMALLFONT}{BLACK}Select text colour
 STR_2991    :Sign
 STR_2992    :Sign text
-STR_2993    :Enter new text for this sign:-
+STR_2993    :Enter new text for this sign:
 STR_2994    :{SMALLFONT}{BLACK}Change text on sign
 STR_2995    :{SMALLFONT}{BLACK}Demolish this sign
 STR_2996    :{BLACK}ABC
@@ -3317,9 +3317,9 @@ STR_3310    :{WINDOW_COLOUR_2}{LENGTH}
 STR_3311    :{WINDOW_COLOUR_2}{COMMA2DP32}
 STR_3312    :{WINDOW_COLOUR_2}Rides/attractions under a preservation order:
 STR_3313    :Scenario Name
-STR_3314    :Enter name for scenario:-
+STR_3314    :Enter name for scenario:
 STR_3315    :Park/Scenario Details
-STR_3316    :Enter description of this scenario:-
+STR_3316    :Enter description of this scenario:
 STR_3317    :No details yet
 STR_3318    :{SMALLFONT}{BLACK}Select which group this scenario appears in
 STR_3319    :{WINDOW_COLOUR_2}Scenario Group:
@@ -3354,7 +3354,7 @@ STR_3347    :Ride is too large, contains too many elements, or scenery is too sp
 STR_3348    :Rename
 STR_3349    :Borrar
 STR_3350    :Track design name
-STR_3351    :Enter new name for this track design:-
+STR_3351    :Enter new name for this track design:
 STR_3352    :Can't rename track design...
 STR_3353    :New name contains invalid characters
 STR_3354    :Another file exists with this name, or file is write-protected

--- a/data/language/swedish.txt
+++ b/data/language/swedish.txt
@@ -857,7 +857,7 @@ STR_0852    :{WINDOW_COLOUR_2}Grafik av Simon Foster
 STR_0853    :{WINDOW_COLOUR_2}Ljud och musik av Allister Brimble
 STR_0854    :{WINDOW_COLOUR_2}Ytterligare ljud inspelade av David Ellis
 STR_0855    :{WINDOW_COLOUR_2}Representation av Jacqui Lyons från Marjacq Ltd.
-STR_0856    :{WINDOW_COLOUR_2}Tack till:-
+STR_0856    :{WINDOW_COLOUR_2}Tack till:
 STR_0857    :{WINDOW_COLOUR_2}Peter James Adcock, Joe Booth, och John Wardley
 STR_0858    :{WINDOW_COLOUR_2}
 STR_0859    :{WINDOW_COLOUR_2}
@@ -1059,7 +1059,7 @@ STR_1054    :{SMALLFONT}{BLACK}Namnge åktur/attraktion
 STR_1055    :{SMALLFONT}{BLACK}Namnge person
 STR_1056    :{SMALLFONT}{BLACK}Namnge anställd
 STR_1057    :Åkturens/attraktionens namn
-STR_1058    :Skriv in ett nytt namn för den här åkturen/attraktionen:-
+STR_1058    :Skriv in ett nytt namn för den här åkturen/attraktionen:
 STR_1059    :Kan inte namnge åktur/attraktion...
 STR_1060    :Ogiltigt åktur/attraktionsnamn
 STR_1061    :Normalt läge
@@ -1455,7 +1455,7 @@ STR_1449    :{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1450    :{INLINE_SPRITE}{09}{20}{00}{00}{SPRITE} {STRINGID}{NEWLINE}({STRINGID})
 STR_1451    :{STRINGID}{NEWLINE}({STRINGID})
 STR_1452    :Gästens namn
-STR_1453    :Skriv in namn för den här gästen:-
+STR_1453    :Skriv in namn för den här gästen:
 STR_1454    :Kan inte namnge gäst...
 STR_1455    :Ogiltigt gästnamn
 STR_1456    :{WINDOW_COLOUR_2}Spenderade pengar: {BLACK}{CURRENCY2DP}
@@ -1722,7 +1722,7 @@ STR_1715    :{INLINE_SPRITE}{250}{19}{00}{00}{WINDOW_COLOUR_2}Klipp gräs
 STR_1716    :Ogiltigt parknamn
 STR_1717    :Kan inte namnge park...
 STR_1718    :Parknamn
-STR_1719    :Skriv in namn på parken:-
+STR_1719    :Skriv in namn på parken:
 STR_1720    :{SMALLFONT}{BLACK}Namnge park
 STR_1721    :Parken är stängd
 STR_1722    :Parken är öppen
@@ -1896,7 +1896,7 @@ STR_1889    :{WINDOW_COLOUR_2}Dötid: {MOVE_X}{255}{BLACK}{COMMA16}%
 STR_1890    :{SMALLFONT}{BLACK}Välj hur ofta en mekaniker ska göra underhåll på den här åkturen
 STR_1891    :Ingen {STRINGID} i parken än!
 STR_1892    :RollerCoaster Tycoon 2
-STR_1893    :Var god sätt in din RollerCoaster Tycoon 2-skiva i följande CD-läsare:-
+STR_1893    :Var god sätt in din RollerCoaster Tycoon 2-skiva i följande CD-läsare:
 STR_1894    :{WINDOW_COLOUR_2}{STRINGID} sålde: {BLACK}{COMMA32}
 STR_1895    :{SMALLFONT}{BLACK}Bygg ny Åktur/attraktion
 STR_1896    :{WINDOW_COLOUR_2}Utgifter/Inkomster
@@ -2252,8 +2252,8 @@ STR_2245    :Oktober
 STR_2246    :November
 STR_2247    :December
 STR_2248    :Kan inte riva åktur/attraktion...
-STR_2249    :{BABYBLUE}Ny åktur/attraktion är nu tillgänglig:-{NEWLINE}{STRINGID}
-STR_2250    :{BABYBLUE}Nya dekorationer/teman är nu tillgängliga:-{NEWLINE}{STRINGID}
+STR_2249    :{BABYBLUE}Ny åktur/attraktion är nu tillgänglig:{NEWLINE}{STRINGID}
+STR_2250    :{BABYBLUE}Nya dekorationer/teman är nu tillgängliga:{NEWLINE}{STRINGID}
 STR_2251    :Kan bara byggas på gångvägar!
 STR_2252    :Kan bara byggas över gångvägar!
 STR_2253    :Transportåkturer
@@ -2790,7 +2790,7 @@ STR_2781    :{STRINGID}:{MOVE_X}{195}{STRINGID}{STRINGID}
 STR_2782    :SHIFT + 
 STR_2783    :CTRL + 
 STR_2784    :Ändra snabbtangenter
-STR_2785    :{WINDOW_COLOUR_2}Välj ny snabbtangent för:-{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
+STR_2785    :{WINDOW_COLOUR_2}Välj ny snabbtangent för:{NEWLINE}{OPENQUOTES}{STRINGID}{ENDQUOTES}
 STR_2786    :{SMALLFONT}{BLACK}Klicka på en beskrivning för att välja en ny snabbtangent
 STR_2787    :{WINDOW_COLOUR_2}Parkvärde: {BLACK}{CURRENCY}
 STR_2788    :{WINDOW_COLOUR_2}Grattis !{NEWLINE}{BLACK}Du uppnådde ditt mål med ett företagsvärde på {CURRENCY} !
@@ -2799,7 +2799,7 @@ STR_2789    :{WINDOW_COLOUR_2}Du har misslyckats med ditt mål !
 STR_2790    :Skriv in namn i scenario chart
 STR_2791    :Skriv in namn
 #TODO
-STR_2792    :Var god skriv in ditt namn i scenario chart:-
+STR_2792    :Var god skriv in ditt namn i scenario chart:
 STR_2793    :{SMALLFONT}(Avklarad av {STRINGID})
 STR_2794    :{WINDOW_COLOUR_2}Avklarad av: {BLACK}{STRINGID}{NEWLINE}{WINDOW_COLOUR_2} med ett företagsvärde på: {BLACK}{CURRENCY}
 STR_2795    :Sortera
@@ -2985,12 +2985,12 @@ STR_2974    :Fjärde färg
 STR_2975    :{SMALLFONT}{BLACK}Välj vilken färgpalett som ska ändras eller användas för målning av en åktur
 STR_2976    :{SMALLFONT}{BLACK}Måla ett enstaka område på denna åktur med den valda färgpaletten
 STR_2977    :Personalnamn
-STR_2978    :Skriv in nytt namn på personal:-
+STR_2978    :Skriv in nytt namn på personal:
 STR_2979    :Kan inte namnge personal...
 STR_2980    :För många banderoller i spelet
 STR_2981    :{RED}Tillträde förbjudet - - 
 STR_2982    :Banderolltext
-STR_2983    :Skriv in ny text för denna banderoll:-
+STR_2983    :Skriv in ny text för denna banderoll:
 STR_2984    :Kan inte sätta ny text på banderollen...
 STR_2985    :Banderoll
 STR_2986    :{SMALLFONT}{BLACK}Byt text på banderoll
@@ -3000,7 +3000,7 @@ STR_2989    :{SMALLFONT}{BLACK}Välj huvudfärg
 STR_2990    :{SMALLFONT}{BLACK}Välj textfärg
 STR_2991    :Banderoll
 STR_2992    :Skylttext
-STR_2993    :Skriv in ny text för denna skylt:-
+STR_2993    :Skriv in ny text för denna skylt:
 STR_2994    :{SMALLFONT}{BLACK}Byt text på skylt
 STR_2995    :{SMALLFONT}{BLACK}Riv denna skylt
 STR_2996    :{BLACK}ABC
@@ -3321,9 +3321,9 @@ STR_3310    :{WINDOW_COLOUR_2}{LENGTH}
 STR_3311    :{WINDOW_COLOUR_2}{COMMA2DP32}
 STR_3312    :{WINDOW_COLOUR_2}Åkturer/attraktioner som måste bevaras:
 STR_3313    :Scenarionamn
-STR_3314    :Skriv in namn för scenario:-
+STR_3314    :Skriv in namn för scenario:
 STR_3315    :Park- och Scenariodetails
-STR_3316    :Skriv in en beskriving för detta scenario:-
+STR_3316    :Skriv in en beskriving för detta scenario:
 STR_3317    :Inga detaljer än
 STR_3318    :{SMALLFONT}{BLACK}Välj vilken grupp detta scenario hör till
 STR_3319    :{WINDOW_COLOUR_2}Scenariogrupp:
@@ -3358,7 +3358,7 @@ STR_3347    :Åkturen är för stor, innehåller för många delar, eller så ä
 STR_3348    :Döp om
 STR_3349    :Ta bort
 STR_3350    :Bandesignnamn
-STR_3351    :Skriv in nytt namn på denna bandesign:-
+STR_3351    :Skriv in nytt namn på denna bandesign:
 STR_3352    :Kan inte namnge bandesign...
 STR_3353    :Det nya namnet innehåller ogiltiga bokstäver eller symboler
 STR_3354    :En annan fil finns redan med detta namn, eller så är filen skrivskyddad


### PR DESCRIPTION
As discussed at issue #521 This pull request removes all dashes behind the colons. Did I made any mistake, like removing ones, which shouldn't be removed? Or did I forgot one? If so, please comment and I'll fix it!