### PR TITLE
Increased the number of rain pixels to max

### DIFF
--- a/src/drawing/drawing.c
+++ b/src/drawing/drawing.c
@@ -31,7 +31,7 @@ int gLastDrawStringY;
 
 uint8 _screenDirtyBlocks[5120];
 
-#define MAX_RAIN_PIXELS 0x9000
+#define MAX_RAIN_PIXELS 0xFFFE
 uint32 rainPixels[MAX_RAIN_PIXELS];
 
 //Originally 0x9ABE0C, 12 elements from 0xF3 are the peep top colour, 12 elements from 0xCA are peep trouser colour


### PR DESCRIPTION
I've increased the number of rain pixels for the third time without doing changes to the code this is the maximum for now. Ideally this would be dynamically allocated but I see no reason to do this for right now. I haven't tested this as the previous maximum was never reached at max resolution on my monitor. (Technically it could be increased to 0xFFFF but I never like to do that incase there is a compare with one above the value. Almost definatley sure there isn't but no point taking the risk.)