### PR TITLE
Fixed secondary item count

### DIFF
--- a/src/ride/ride.h
+++ b/src/ride/ride.h
@@ -218,8 +218,8 @@ typedef struct {
 	uint8 var_1A1;
 	uint8 var_1A2;
 	uint8 var_1A3;
-	uint32 var_1A4;
-	uint8 pad_1A8[4];
+	uint32 no_primary_items_sold;
+	uint32 no_secondary_items_sold;
 	uint8 var_1AC;
 	uint8 var_1AD;
 	uint8 var_1AE;

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -5787,7 +5787,7 @@ static void window_ride_customer_paint()
 			stringId += 96;
 
 		RCT2_GLOBAL(0x013CE952 + 0, uint16) = stringId;
-		RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->var_1A4;
+		RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->no_primary_items_sold;
 		gfx_draw_string_left(dpi, STR_ITEMS_SOLD, (void*)0x013CE952, 0, x, y);
 		y += 10;
 	}
@@ -5802,7 +5802,7 @@ static void window_ride_customer_paint()
 			stringId += 96;
 
 		RCT2_GLOBAL(0x013CE952 + 0, uint16) = stringId;
-		RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->var_1A4;
+		RCT2_GLOBAL(0x013CE952 + 2, uint32) = ride->no_secondary_items_sold;
 		gfx_draw_string_left(dpi, STR_ITEMS_SOLD, (void*)0x013CE952, 0, x, y);
 		y += 10;
 	}


### PR DESCRIPTION
Fixes #670
Mistake caused by using the primary offset for the secondary count.
I've also labeled count offsets in the ride struct.