### PR TITLE
Fix #672

### DIFF
--- a/src/windows/text_input.c
+++ b/src/windows/text_input.c
@@ -57,7 +57,7 @@ static void window_text_input_emptysub(){}
 static void window_text_input_mouseup();
 static void window_text_input_paint();
 static void window_text_input_text(int key, rct_window* w);
-static void window_text_input_update(rct_window* w);
+static void window_text_input_update7();
 static void window_text_input_close();
 static void window_text_input_invalidate();
 
@@ -69,8 +69,8 @@ static void* window_text_input_events[] = {
 	window_text_input_emptysub,
 	window_text_input_emptysub,
 	window_text_input_emptysub,
-	window_text_input_update,
 	window_text_input_emptysub,
+	window_text_input_update7,
 	window_text_input_emptysub,
 	window_text_input_emptysub,
 	window_text_input_emptysub,
@@ -281,8 +281,12 @@ static void window_text_input_text(int key, rct_window* w){
 	window_invalidate(w);
 }
 
-void window_text_input_update(rct_window* w)
+void window_text_input_update7()
 {
+	rct_window* w;
+
+	window_get_register(w);
+
 	rct_window* calling_w = window_find_by_number(calling_class, calling_number);
 	// If the calling window is closed then close the text
 	// input window.


### PR DESCRIPTION
Fix #672.
Moved text_input update to unknown7 function in order to force updates when paused.
This is a bit of a hack but then so is all of the text input window. Unknown7 is called every 1000 ticks and also during game_handle_update every tick. This is roughly the same as every tick but still occurs when paused.