### PR TITLE
Fix intro

### DIFF
--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -50,10 +50,6 @@ static const char *const usage[] = {
  */
 int cmdline_run(const char **argv, int argc)
 {
-	// For argparse's sake, add virtual first argument process path
-	argc++;
-	argv--;
-
 	// 
 	int version = 0, verbose = 0, width = 0, height = 0;
 

--- a/src/drawing/drawing.c
+++ b/src/drawing/drawing.c
@@ -136,7 +136,7 @@ void gfx_transpose_palette(int pal, unsigned char product)
 	rct_g1_element g1 = RCT2_ADDRESS(RCT2_ADDRESS_G1_ELEMENTS, rct_g1_element)[pal];
 	int width = g1.width;
 	int x = g1.x_offset;  
-	uint8* dest_pointer = (uint8*)&(RCT2_ADDRESS(0x014124680,uint8)[x]);
+	uint8* dest_pointer = (uint8*)&(RCT2_ADDRESS(0x01424680, uint8)[x * 4]);
 	uint8* source_pointer = g1.offset;
 
 	for (; width > 0; width--) {

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -70,7 +70,7 @@ __declspec(dllexport) int StartOpenRCT(HINSTANCE hInstance, HINSTANCE hPrevInsta
 	// Get command line arguments in standard form
 	argv = CommandLineToArgvA(lpCmdLine, &argc);
 	runGame = cmdline_run(argv, argc);
-	//LocalFree(argv);
+	GlobalFree(argv);
 
 	if (runGame)
 		openrct2_launch();
@@ -243,11 +243,13 @@ PCHAR *CommandLineToArgvA(PCHAR CmdLine, int *_argc)
 	i = ((len + 2) / 2)*sizeof(PVOID) + sizeof(PVOID);
 
 	argv = (PCHAR*)GlobalAlloc(GMEM_FIXED,
-		i + (len + 2)*sizeof(CHAR));
+		i + (len + 2)*sizeof(CHAR) + 1);
 
 	_argv = (PCHAR)(((PUCHAR)argv) + i);
 
-	argc = 0;
+	// Add in virtual 1st command line argument, process path, for arg_parse's sake.
+	argv[0] = 0;
+	argc = 1;
 	argv[argc] = _argv;
 	in_QM = FALSE;
 	in_TEXT = FALSE;

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -70,7 +70,7 @@ __declspec(dllexport) int StartOpenRCT(HINSTANCE hInstance, HINSTANCE hPrevInsta
 	// Get command line arguments in standard form
 	argv = CommandLineToArgvA(lpCmdLine, &argc);
 	runGame = cmdline_run(argv, argc);
-	LocalFree(argv);
+	//LocalFree(argv);
 
 	if (runGame)
 		openrct2_launch();


### PR DESCRIPTION
Fix to #693.

There was an incorrect pointer assignment in transpose palette causing a crash. I also found a mistake in the audio when the channels are set to 0 that prevented sound from playing. I've also rejiged the windows command line reading to prevent arg_parse from accessing invalid memory.