### PR TITLE
Fix mechanics getting orders reset

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -1626,7 +1626,7 @@ rct_peep *find_closest_mechanic(int x, int y, int forInspection)
 			if (!(peep->staff_orders & 2))
 				continue;
 		} else {
-			if (peep->state != PEEP_STATE_PATROLLING && !(peep->staff_orders & 1))
+			if (peep->state != PEEP_STATE_PATROLLING || !(peep->staff_orders & 1))
 				continue;
 		}
 


### PR DESCRIPTION
Fixes #718.

Any save files with mechanics in odd positions will need to be picked up and dropped to make them able to fix things again.