### PR TITLE
Fix scenery rating crash

### DIFF
--- a/src/ride/ride_ratings.c
+++ b/src/ride/ride_ratings.c
@@ -733,8 +733,8 @@ static int ride_ratings_get_scenery_score(rct_ride *ride)
 
 	// Count surrounding scenery items
 	numSceneryItems = 0;
-	for (yy = y - 5; yy <= y + 5; yy++) {
-		for (xx = x - 5; xx <= x + 5; xx++) {
+	for (yy = max(y - 5, 0); yy <= y + 5; yy++) {
+		for (xx = max(x - 5, 0); xx <= x + 5; xx++) {
 			// Count scenery items on this tile
 			mapElement = map_get_first_element_at(xx, yy);
 			do {

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -88,7 +88,7 @@ void map_element_iterator_restart_for_tile(map_element_iterator *it)
 
 rct_map_element *map_get_first_element_at(int x, int y)
 {
-	if (x < 0 || y < 0)
+	if (x < 0 || y < 0 || x > 255 || y > 255)
 	{ 
 		log_error("Trying to access element outside of range"); 
 		return NULL;

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -88,6 +88,11 @@ void map_element_iterator_restart_for_tile(map_element_iterator *it)
 
 rct_map_element *map_get_first_element_at(int x, int y)
 {
+	if (x < 0 || y < 0)
+	{ 
+		log_error("Trying to access element outside of range"); 
+		return NULL;
+	}
 	return TILE_MAP_ELEMENT_POINTER(x + y * 256);
 }
 


### PR DESCRIPTION
Fixes part of #728.

When working out ride rating it tries to access elements that could be outside of the range of map elements.