### PR TITLE
Small Ride Window Fixes

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -685,7 +685,7 @@ static void ride_remove_peeps(int rideIndex)
 				if (peep->next_var_29 & 4)
 					z += 8;
 				z++;
-				sprite_move(exitX, exitY, exitZ, (rct_sprite*)peep);
+				sprite_move(x, y, z, (rct_sprite*)peep);
 			} else {
 				sprite_move(exitX, exitY, exitZ, (rct_sprite*)peep);
 				peep->sprite_direction = exitDirection;

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -5466,7 +5466,7 @@ static void window_ride_income_invalidate()
 				w->pressed_widgets |= (1 << WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK);
 		} else {
 			secondaryItem -= 32;
-			if (RCT2_GLOBAL(0x0135884C, uint32) & (1 << secondaryItem))
+			if (RCT2_GLOBAL(0x0135934C, uint32) & (1 << secondaryItem))
 				w->pressed_widgets |= (1 << WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK);
 		}
 

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -5540,9 +5540,9 @@ static void window_ride_income_paint()
 		profit = ride->price_secondary;
 
 		stringId = STR_PROFIT_PER_ITEM_SOLD;
-		profit -= primaryItem < 32 ?
-			RCT2_GLOBAL(0x00982164 + (primaryItem * 8), uint16) :
-			RCT2_GLOBAL(0x00982144 + (primaryItem * 8), uint16);
+		profit -= secondaryItem < 32 ?
+			RCT2_GLOBAL(0x00982164 + (secondaryItem * 8), uint16) :
+			RCT2_GLOBAL(0x00982144 + (secondaryItem * 8), uint16);
 		if (profit < 0) {
 			profit *= -1;
 			stringId = STR_LOSS_PER_ITEM_SOLD;


### PR DESCRIPTION
Fixes #731

There was a mistake in the secondary price loss per item for rides. It used the primary item for the calculation.

There was also an issue (incorrect pointer value) causing the secondary item price same throughout park to not be displayed correctly.