### PR TITLE
[suggestion/RFC] Refactor placement of top toolbar widgets

### DIFF
--- a/src/windows/editor_top_toolbar.c
+++ b/src/windows/editor_top_toolbar.c
@@ -47,6 +47,8 @@ enum WINDOW_EDITOR_TOP_TOOLBAR_WIDGET_IDX {
 	WIDX_UNUSED3,				// 14, 4000
 	WIDX_UNUSED4,				// 15, 8000
 	WIDX_CLEAR_SCENERY,			// 16, 10000
+
+	WIDX_SEPARATOR,
 };
 
 typedef enum {
@@ -64,6 +66,32 @@ typedef enum {
 	DDIDX_TD_SCREENSHOT = 2,
 	DDIDX_TD_QUIT_GAME = 4,
 } TRACK_DESINGER_FILE_MENU_DDIDX;
+
+#pragma region Toolbar_widget_ordering
+
+// from left to right
+static const int left_aligned_widgets_order[] = {
+	WIDX_PAUSE, WIDX_FILE_MENU,
+
+	WIDX_SEPARATOR,
+
+	WIDX_ZOOM_OUT,
+	WIDX_ZOOM_IN,
+	WIDX_ROTATE,
+	WIDX_VIEW_MENU,
+	WIDX_MAP,
+};
+
+// from right to left
+static const int right_aligned_widgets_order[] = {
+	WIDX_CONSTRUCT_RIDE, WIDX_PATH,
+	WIDX_SCENERY,
+	WIDX_WATER,
+	WIDX_LAND,
+	WIDX_CLEAR_SCENERY,
+};
+
+#pragma endregion
 
 static rct_widget window_editor_top_toolbar_widgets[] = {
 	{ WWT_EMPTY, 0, 0, 0, 0, 0, 0xFFFFFFFF, 0xFFFF },														// 1		0x009A9844
@@ -83,6 +111,8 @@ static rct_widget window_editor_top_toolbar_widgets[] = {
 	{ WWT_EMPTY, 0, 0, 0, 0, 0, 0xFFFFFFFF, 0xFFFF },														// 4000		0x009A9924
 	{ WWT_EMPTY, 0, 0, 0, 0, 0, 0xFFFFFFFF, 0xFFFF },														// 8000		0x009A9934
 	{ WWT_TRNBTN, 2, 560, 589, 0, 27, 0x20000000 | SPR_TOOLBAR_CLEAR_SCENERY, STR_CLEAR_SCENERY_TIP },		// 10000	0x009A9944
+
+	{ WWT_EMPTY, 0, 0, 10-1, 0, 0, 0xFFFFFFFF, 0xFFFF },													// Artificial widget separator
 	{ WIDGETS_END },
 };
 
@@ -324,36 +354,6 @@ void window_editor_top_toolbar_invalidate()
 
 	window_get_register(w);
 
-	sint16 screenWidth = max(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_WIDTH, sint16), 640);
-
-	window_editor_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].left = screenWidth - 30;
-	window_editor_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].right =
-		window_editor_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].left + 29;
-
-	window_editor_top_toolbar_widgets[WIDX_PATH].left = screenWidth - 30;
-	window_editor_top_toolbar_widgets[WIDX_PATH].right =
-		window_editor_top_toolbar_widgets[WIDX_PATH].left + 29;
-
-	window_editor_top_toolbar_widgets[WIDX_SCENERY].left =
-		window_editor_top_toolbar_widgets[WIDX_PATH].left - 30;
-	window_editor_top_toolbar_widgets[WIDX_SCENERY].right =
-		window_editor_top_toolbar_widgets[WIDX_SCENERY].left + 29;
-
-	window_editor_top_toolbar_widgets[WIDX_WATER].left =
-		window_editor_top_toolbar_widgets[WIDX_SCENERY].left - 30;
-	window_editor_top_toolbar_widgets[WIDX_WATER].right =
-		window_editor_top_toolbar_widgets[WIDX_WATER].left + 29;
-
-	window_editor_top_toolbar_widgets[WIDX_LAND].left =
-		window_editor_top_toolbar_widgets[WIDX_WATER].left - 30;
-	window_editor_top_toolbar_widgets[WIDX_LAND].right =
-		window_editor_top_toolbar_widgets[WIDX_LAND].left + 29;
-
-	window_editor_top_toolbar_widgets[WIDX_CLEAR_SCENERY].left =
-		window_editor_top_toolbar_widgets[WIDX_LAND].left - 30;
-	window_editor_top_toolbar_widgets[WIDX_CLEAR_SCENERY].right =
-		window_editor_top_toolbar_widgets[WIDX_CLEAR_SCENERY].left + 29;
-
 	window_editor_top_toolbar_widgets[WIDX_ZOOM_OUT].type = WWT_EMPTY;
 	window_editor_top_toolbar_widgets[WIDX_ZOOM_IN].type = WWT_EMPTY;
 	window_editor_top_toolbar_widgets[WIDX_ROTATE].type = WWT_EMPTY;
@@ -390,6 +390,36 @@ void window_editor_top_toolbar_invalidate()
 		w->pressed_widgets &= ~(1 << WIDX_PATH);
 	else
 		w->pressed_widgets |= (1 << WIDX_PATH);
+
+	sint16 x = max(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_WIDTH, sint16), 640);
+
+	for (int i = 0; i < countof(right_aligned_widgets_order); ++i) {
+		rct_widget *current_widget = &window_editor_top_toolbar_widgets[right_aligned_widgets_order[i]];
+		int widget_width = current_widget->right - current_widget->left;
+
+		if (current_widget->type == WWT_EMPTY && right_aligned_widgets_order[i] != WIDX_SEPARATOR)
+			continue;
+
+		x -= 1;
+		current_widget->right = x;
+		x -= widget_width;
+		current_widget->left = x;
+	}
+
+	x = 0;
+
+	for (int i = 0; i < countof(left_aligned_widgets_order); ++i) {
+		rct_widget *current_widget = &window_editor_top_toolbar_widgets[left_aligned_widgets_order[i]];
+		int widget_width = current_widget->right - current_widget->left;
+
+		if (current_widget->type == WWT_EMPTY && left_aligned_widgets_order[i] != WIDX_SEPARATOR)
+			continue;
+
+		current_widget->left = x;
+		x += widget_width;
+		current_widget->right = x;
+		x += 1;
+	}
 }
 
 /**

--- a/src/windows/game_bottom_toolbar.c
+++ b/src/windows/game_bottom_toolbar.c
@@ -47,21 +47,26 @@ enum WINDOW_GAME_BOTTOM_TOOLBAR_WIDGET_IDX {
 	WIDX_DATE
 };
 
+
+// Right panel needs to be a bit bigger than original so dates like "22nd September, Year 126" can fit.
+// Left panel size was also increased for symmetry.
+#define WIDTH_MOD 22
+
 rct_widget window_game_bottom_toolbar_widgets[] = {
-	{ WWT_IMGBTN,	0,	0x0000,	0x0077,	0,		33,		0xFFFFFFFF,	STR_NONE },	// Left outset panel
-	{ WWT_IMGBTN,	0,	0x0002,	0x0075,	2,		31,		0xFFFFFFFF,	STR_NONE },	// Left inset panel
-	{ WWT_FLATBTN,	0,	0x0002,	0x0075,	1,		12,		0xFFFFFFFF,	STR_PROFIT_PER_WEEK_AND_PARK_VALUE_TIP },	// Money window
-	{ WWT_FLATBTN,	0,	0x0002,	0x0075,	11,		22,		0xFFFFFFFF,	STR_NONE },	// Guests window
-	{ WWT_FLATBTN,	0,	0x0002,	0x0075,	21,		31,		0xFFFFFFFF,	STR_PARK_RATING_TIP },	// Park rating window
+	{ WWT_IMGBTN,	0,	0x0000,	0x0077+WIDTH_MOD,	0,		33,		0xFFFFFFFF,	STR_NONE },	// Left outset panel
+	{ WWT_IMGBTN,	0,	0x0002,	0x0075+WIDTH_MOD,	2,		31,		0xFFFFFFFF,	STR_NONE },	// Left inset panel
+	{ WWT_FLATBTN,	0,	0x0002,	0x0075+WIDTH_MOD,	1,		12,		0xFFFFFFFF,	STR_PROFIT_PER_WEEK_AND_PARK_VALUE_TIP },	// Money window
+	{ WWT_FLATBTN,	0,	0x0002,	0x0075+WIDTH_MOD,	11,		22,		0xFFFFFFFF,	STR_NONE },	// Guests window
+	{ WWT_FLATBTN,	0,	0x0002,	0x0075+WIDTH_MOD,	21,		31,		0xFFFFFFFF,	STR_PARK_RATING_TIP },	// Park rating window
 
-	{ WWT_IMGBTN,	2,	0x0078,	0x0207,	0,		33,		0xFFFFFFFF,	STR_NONE },	// Middle outset panel
-	{ WWT_25,		2,	0x007A,	0x0205,	2,		31,		0xFFFFFFFF,	STR_NONE },	// Middle inset panel
-	{ WWT_FLATBTN,	2,	0x007D,	0x0094,	5,		28,		0xFFFFFFFF,	STR_SHOW_SUBJECT_TIP },	// Associated news item window
-	{ WWT_FLATBTN,	2,	0x01EB,	0x0202,	5,		28,		SPR_LOCATE,	STR_LOCATE_SUBJECT_TIP },	// Scroll to news item target
+	{ WWT_IMGBTN,	2,	0x0078+WIDTH_MOD,	0x0207-WIDTH_MOD,	0,		33,		0xFFFFFFFF,	STR_NONE },	// Middle outset panel
+	{ WWT_25,		2,	0x007A+WIDTH_MOD,	0x0205-WIDTH_MOD,	2,		31,		0xFFFFFFFF,	STR_NONE },	// Middle inset panel
+	{ WWT_FLATBTN,	2,	0x007D+WIDTH_MOD,	0x0094+WIDTH_MOD,	5,		28,		0xFFFFFFFF,	STR_SHOW_SUBJECT_TIP },	// Associated news item window
+	{ WWT_FLATBTN,	2,	0x01EB-WIDTH_MOD,	0x0202-WIDTH_MOD,	5,		28,		SPR_LOCATE,	STR_LOCATE_SUBJECT_TIP },	// Scroll to news item target
 
-	{ WWT_IMGBTN,	0,	0x0208,	0x027F,	0,		33,		0xFFFFFFFF,	STR_NONE },	// Right outset panel
-	{ WWT_IMGBTN,	0,	0x020A,	0x027D,	2,		31,		0xFFFFFFFF,	STR_NONE },	// Right inset panel
-	{ WWT_FLATBTN,	0,	0x020A,	0x027D,	2,		13,		0xFFFFFFFF,	2290 },	// Date
+	{ WWT_IMGBTN,	0,	0x0208-WIDTH_MOD,	0x027F,	0,		33,		0xFFFFFFFF,	STR_NONE },	// Right outset panel
+	{ WWT_IMGBTN,	0,	0x020A-WIDTH_MOD,	0x027D,	2,		31,		0xFFFFFFFF,	STR_NONE },	// Right inset panel
+	{ WWT_FLATBTN,	0,	0x020A-WIDTH_MOD,	0x027D,	2,		13,		0xFFFFFFFF,	2290 },	// Date
 	{ WIDGETS_END },
 };
 
@@ -268,7 +273,7 @@ static void window_game_bottom_toolbar_invalidate()
 	window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right = x;
 	x -= 2;
 	window_game_bottom_toolbar_widgets[WIDX_RIGHT_INSET].right = x;
-	x -= 115;
+	x -= (115 + WIDTH_MOD);
 	window_game_bottom_toolbar_widgets[WIDX_RIGHT_INSET].left = x;
 	x -= 2;
 	window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left = x;
@@ -441,8 +446,8 @@ static void window_game_bottom_toolbar_draw_park_rating(rct_drawpixelinfo *dpi, 
 {
 	short bar_width;
 
-	bar_width = (factor * 90) / 256;
-	gfx_fill_rect_inset(dpi, x, y + 1, x + 93, y + 9, w->colours[1], 48);
+	bar_width = (factor * (90 + WIDTH_MOD)) / 256;
+	gfx_fill_rect_inset(dpi, x, y + 1, x + (93 + WIDTH_MOD), y + 9, w->colours[1], 48);
 	if (!(colour & 0x80000000) || RCT2_GLOBAL(RCT2_ADDRESS_GAME_PAUSED, uint8) != 0 || (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TICKS, uint8) & 8)) {
 		if (bar_width > 2)
 			gfx_fill_rect_inset(dpi, x + 2, y + 2, x + bar_width - 1, y + 8, colour & 0x7FFFFFFF, 0);
@@ -450,7 +455,7 @@ static void window_game_bottom_toolbar_draw_park_rating(rct_drawpixelinfo *dpi, 
 
 	// Draw thumbs on the sides
 	gfx_draw_sprite(dpi, SPR_RATING_LOW, x - 14, y, 0);
-	gfx_draw_sprite(dpi, SPR_RATING_HIGH, x + 92, y, 0);
+	gfx_draw_sprite(dpi, SPR_RATING_HIGH, x + (92 + WIDTH_MOD), y, 0);
 }
 
 static void window_game_bottom_toolbar_draw_right_panel(rct_drawpixelinfo *dpi, rct_window *w)

--- a/src/windows/game_top_toolbar.c
+++ b/src/windows/game_top_toolbar.c
@@ -53,7 +53,9 @@ enum {
 
 	//WIDX_FASTFORWARD,
 	WIDX_FINANCES,
-	WIDX_RESEARCH
+	WIDX_RESEARCH,
+
+	WIDX_SEPARATOR,
 };
 
 typedef enum {
@@ -67,17 +69,14 @@ typedef enum {
 
 #pragma region Toolbar_widget_ordering
 
-// todo: declare separators in the widget list itself
-
 // from left to right
 static const int left_aligned_widgets_order[] = {
 	WIDX_PAUSE,
 	//WIDX_FASTFORWARD,
 	WIDX_FILE_MENU,
-};
 
-// from left to right
-static const int left_separator_aligned_widgets_order[] = {
+	WIDX_SEPARATOR,
+
 	WIDX_ZOOM_OUT,
 	WIDX_ZOOM_IN,
 	WIDX_ROTATE,
@@ -93,10 +92,9 @@ static const int right_aligned_widgets_order[] = {
 	WIDX_RIDES,
 	WIDX_RESEARCH,
 	WIDX_FINANCES,
-};
 
-// from right to left
-static const int right_separator_aligned_widgets_order[] = {
+	WIDX_SEPARATOR,
+
 	WIDX_CONSTRUCT_RIDE,
 	WIDX_PATH,
 	WIDX_SCENERY,
@@ -130,6 +128,8 @@ static rct_widget window_game_top_toolbar_widgets[] = {
 	//{ WWT_TRNBTN,	0,	0x001E,	0x003B,	0,						27,		0x20000000 | 0x15F9,						STR_NONE },							// Fast forward
 	{ WWT_TRNBTN,	3,	0x001E, 0x003B, 0,						27,		0x20000000 | 0x15F9,						3235 },								// Finances
 	{ WWT_TRNBTN,	3,	0x001E,	0x003B,	0,						27,		0x20000000 | 0x15F9,						2275 },								// Research
+	
+	{ WWT_EMPTY,	0,	0,		10-1,	0,						0,		0xFFFFFFFF,									STR_NONE },							// Artificial widget separator
 	{ WIDGETS_END },
 };
 
@@ -412,36 +412,24 @@ static void window_game_top_toolbar_invalidate()
 		x = 640;
 
 	for (int i = 0; i < countof(right_aligned_widgets_order); ++i) {
-		x -= 1;
-		window_game_top_toolbar_widgets[right_aligned_widgets_order[i]].right = x;
-		x -= 29;
-		window_game_top_toolbar_widgets[right_aligned_widgets_order[i]].left = x;
-	}
+		rct_widget *current_widget = &window_game_top_toolbar_widgets[right_aligned_widgets_order[i]];
+		int widget_width = current_widget->right - current_widget->left;
 
-	x -= 10;
-
-	for (int i = 0; i < countof(right_separator_aligned_widgets_order); ++i) {
 		x -= 1;
-		window_game_top_toolbar_widgets[right_separator_aligned_widgets_order[i]].right = x;
-		x -= 29;
-		window_game_top_toolbar_widgets[right_separator_aligned_widgets_order[i]].left = x;
+		current_widget->right = x;
+		x -= widget_width;
+		current_widget->left = x;
 	}
 
 	x = 0;
 
 	for (int i = 0; i < countof(left_aligned_widgets_order); ++i) {
-		window_game_top_toolbar_widgets[left_aligned_widgets_order[i]].left = x;
-		x += 29;
-		window_game_top_toolbar_widgets[left_aligned_widgets_order[i]].right = x;
-		x += 1;
-	}
+		rct_widget *current_widget = &window_game_top_toolbar_widgets[left_aligned_widgets_order[i]];
+		int widget_width = current_widget->right - current_widget->left;
 
-	x += 10;
-
-	for (int i = 0; i < countof(left_separator_aligned_widgets_order); ++i) {
-		window_game_top_toolbar_widgets[left_separator_aligned_widgets_order[i]].left = x;
-		x += 29;
-		window_game_top_toolbar_widgets[left_separator_aligned_widgets_order[i]].right = x;
+		current_widget->left = x;
+		x += widget_width;
+		current_widget->right = x;
 		x += 1;
 	}
 

--- a/src/windows/game_top_toolbar.c
+++ b/src/windows/game_top_toolbar.c
@@ -65,6 +65,48 @@ typedef enum {
 	DDIDX_QUIT_GAME = 7,
 } FILE_MENU_DDIDX;
 
+#pragma region Toolbar_widget_ordering
+
+// todo: declare separators in the widget list itself
+
+// from left to right
+static const int left_aligned_widgets_order[] = {
+	WIDX_PAUSE,
+	//WIDX_FASTFORWARD,
+	WIDX_FILE_MENU,
+};
+
+// from left to right
+static const int left_separator_aligned_widgets_order[] = {
+	WIDX_ZOOM_OUT,
+	WIDX_ZOOM_IN,
+	WIDX_ROTATE,
+	WIDX_VIEW_MENU,
+	WIDX_MAP,
+};
+
+// from right to left
+static const int right_aligned_widgets_order[] = {
+	WIDX_GUESTS,
+	WIDX_STAFF,
+	WIDX_PARK,
+	WIDX_RIDES,
+	WIDX_RESEARCH,
+	WIDX_FINANCES,
+};
+
+// from right to left
+static const int right_separator_aligned_widgets_order[] = {
+	WIDX_CONSTRUCT_RIDE,
+	WIDX_PATH,
+	WIDX_SCENERY,
+	WIDX_WATER,
+	WIDX_LAND,
+	WIDX_CLEAR_SCENERY,
+};
+
+#pragma endregion
+
 static rct_widget window_game_top_toolbar_widgets[] = {
 	{ WWT_TRNBTN,	0,	0x0000,			0x001D,			0,		27,		0x20000000 | SPR_TOOLBAR_PAUSE,				STR_PAUSE_GAME_TIP },				// Pause
 	{ WWT_TRNBTN,	0,	0x001E + 30,	0x003B + 30,	0,		27,		0x20000000 | SPR_TOOLBAR_FILE,				STR_DISC_AND_GAME_OPTIONS_TIP },	// File menu
@@ -368,86 +410,40 @@ static void window_game_top_toolbar_invalidate()
 	x = RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_WIDTH, sint16);
 	if (x < 640)
 		x = 640;
-	x--;
-	window_game_top_toolbar_widgets[WIDX_GUESTS].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_GUESTS].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_STAFF].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_STAFF].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_PARK].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_PARK].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_RIDES].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_RIDES].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_RESEARCH].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_RESEARCH].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_FINANCES].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_FINANCES].left = x;
-	x -= 11;
-	window_game_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_PATH].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_PATH].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_SCENERY].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_SCENERY].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_WATER].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_WATER].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_LAND].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_LAND].left = x;
-	x -= 1;
-	window_game_top_toolbar_widgets[WIDX_CLEAR_SCENERY].right = x;
-	x -= 29;
-	window_game_top_toolbar_widgets[WIDX_CLEAR_SCENERY].left = x;
+
+	for (int i = 0; i < countof(right_aligned_widgets_order); ++i) {
+		x -= 1;
+		window_game_top_toolbar_widgets[right_aligned_widgets_order[i]].right = x;
+		x -= 29;
+		window_game_top_toolbar_widgets[right_aligned_widgets_order[i]].left = x;
+	}
+
+	x -= 10;
+
+	for (int i = 0; i < countof(right_separator_aligned_widgets_order); ++i) {
+		x -= 1;
+		window_game_top_toolbar_widgets[right_separator_aligned_widgets_order[i]].right = x;
+		x -= 29;
+		window_game_top_toolbar_widgets[right_separator_aligned_widgets_order[i]].left = x;
+	}
+
 	x = 0;
-	window_game_top_toolbar_widgets[WIDX_PAUSE].left = x;
-	x += 29;
-	window_game_top_toolbar_widgets[WIDX_PAUSE].right = x;
-	// x += 1;
-	// window_game_top_toolbar_widgets[WIDX_FASTFORWARD].left = x;
-	// x += 29;
-	// window_game_top_toolbar_widgets[WIDX_FASTFORWARD].right = x;
-	x += 1;
-	window_game_top_toolbar_widgets[WIDX_FILE_MENU].left = x;
-	x += 29;
-	window_game_top_toolbar_widgets[WIDX_FILE_MENU].right = x;
-	x += 11;
-	window_game_top_toolbar_widgets[WIDX_ZOOM_OUT].left = x;
-	x += 29;
-	window_game_top_toolbar_widgets[WIDX_ZOOM_OUT].right = x;
-	x += 1;
-	window_game_top_toolbar_widgets[WIDX_ZOOM_IN].left = x;
-	x += 29;
-	window_game_top_toolbar_widgets[WIDX_ZOOM_IN].right = x;
-	x += 1;
-	window_game_top_toolbar_widgets[WIDX_ROTATE].left = x;
-	x += 29;
-	window_game_top_toolbar_widgets[WIDX_ROTATE].right = x;
-	x += 1;
-	window_game_top_toolbar_widgets[WIDX_VIEW_MENU].left = x;
-	x += 29;
-	window_game_top_toolbar_widgets[WIDX_VIEW_MENU].right = x;
-	x += 1;
-	window_game_top_toolbar_widgets[WIDX_MAP].left = x;
-	x += 29;
-	window_game_top_toolbar_widgets[WIDX_MAP].right = x;
+
+	for (int i = 0; i < countof(left_aligned_widgets_order); ++i) {
+		window_game_top_toolbar_widgets[left_aligned_widgets_order[i]].left = x;
+		x += 29;
+		window_game_top_toolbar_widgets[left_aligned_widgets_order[i]].right = x;
+		x += 1;
+	}
+
+	x += 10;
+
+	for (int i = 0; i < countof(left_separator_aligned_widgets_order); ++i) {
+		window_game_top_toolbar_widgets[left_separator_aligned_widgets_order[i]].left = x;
+		x += 29;
+		window_game_top_toolbar_widgets[left_separator_aligned_widgets_order[i]].right = x;
+		x += 1;
+	}
 
 	// Footpath button pressed down
 	if (window_find_by_class(WC_FOOTPATH) == NULL)


### PR DESCRIPTION
This primarily cleans up `window_game_top_toolbar_invalidate`.
It's now also trivial to reorder the widgets, which may be a small step towards #622:

![image](https://cloud.githubusercontent.com/assets/4729533/6070675/f0aed7ac-ad8e-11e4-9e22-9524c73fe68b.png)

Things to consider before even thinking about merging this:
- this clashes with widget placement defined in `window_game_top_toolbar_widgets[]` - the original layout is unchanged, but it switches to new one almost immediately, on the first call to `invalidate`. May be confusing. Not sure what do to about it.
- it would be cool to be able to have separators (like the empty space between construct ride button and finances button) declared somewhere in the ordering, so there will be no need for `left_separator_aligned_widgets_order` and you could have multiple separators. I thought about adding an enum value `WIDX_SPECIAL_SEPARATOR = -1`, would this be acceptable?
- if this gets closer to merge, editor_top_toolbar should receive the same treatment.