### PR TITLE
Added new strings for units and title screen music

### DIFF
--- a/data/language/dutch.txt
+++ b/data/language/dutch.txt
@@ -2718,30 +2718,30 @@ STR_2716    :/
 STR_2717    :'
 STR_2718    :???
 STR_2719    :???
-STR_2720    :???
-STR_2721    :???
-STR_2722    :???
-STR_2723    :???
-STR_2724    :???
-STR_2725    :???
-STR_2726    :???
-STR_2727    :???
-STR_2728    :???
-STR_2729    :???
-STR_2730    :???
-STR_2731    :???
-STR_2732    :???
-STR_2733    :???
-STR_2734    :???
-STR_2735    :???
-STR_2736    :???
-STR_2737    :???
-STR_2738    :???
-STR_2739    :???
-STR_2740    :???
-STR_2741    :???
-STR_2742    :???
-STR_2743    :???
+STR_2720    :{UINT16}s
+STR_2721    :{UINT16}s
+STR_2722    :{UINT16}m {UINT16}s
+STR_2723    :{UINT16}m {UINT16}s
+STR_2724    :{UINT16}m {UINT16}s
+STR_2725    :{UINT16}m {UINT16}s
+STR_2726    :{UINT16}m
+STR_2727    :{UINT16}m
+STR_2728    :{UINT16}h {UINT16}m
+STR_2729    :{UINT16}h {UINT16}m
+STR_2730    :{UINT16}h {UINT16}m
+STR_2731    :{UINT16}h {UINT16}m
+STR_2732    :{COMMA16} ft
+STR_2733    :{COMMA16} m
+STR_2734    :{COMMA16} mph
+STR_2735    :{COMMA16} km/h
+STR_2736    :{MONTH}, jaar {COMMA16}
+STR_2737    :{STRINGID} {MONTH}, jaar {COMMA16}
+STR_2738    :Titelschermmuziek
+STR_2739    :Geen
+STR_2740    :RollerCoaster Tycoon 1
+STR_2741    :RollerCoaster Tycoon 2
+STR_2742    :css50.dat niet gevonden
+STR_2743    :Kopieer data\css17.dat van je RCT1-installatie naar data\css50.dat in je RCT2-installatie.
 STR_2744    :[
 STR_2745    :\
 STR_2746    :]


### PR DESCRIPTION
Added Dutch translations for recently introduced strings.

String 2720 up to and including 2731 are translated as they are because they most of them are prone to overflowing and thus have to be kept short.
String 2732 up to and including 2735 have a space for readability.
The rest of them should be self-explanatory.