### PR TITLE
Fix negative money due to cheat detection.

### DIFF
--- a/projects/openrct2.vcxproj.user
+++ b/projects/openrct2.vcxproj.user
@@ -4,5 +4,7 @@
     <LocalDebuggerWorkingDirectory>$(TargetDir)</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerCommand>$(TargetDir)\openrct2.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
   </PropertyGroup>
 </Project>

--- a/src/management/news_item.c
+++ b/src/management/news_item.c
@@ -61,13 +61,15 @@ void news_item_update_current()
 
 	ax = RCT2_GLOBAL(RCT2_ADDRESS_OS_TIME_DAY, sint16);
 	bx = RCT2_GLOBAL(RCT2_ADDRESS_OS_TIME_MONTH, sint16);
+
+	// Cheat detection
 	if (bx != RCT2_GLOBAL(0x009DEA6B, sint16)) {
 		bx--;
 		if (bx == 0)
 			bx = 12;
-		if (bx != RCT2_GLOBAL(0x009DEA6B, sint16) || ax == 1) {
+		if (bx != RCT2_GLOBAL(0x009DEA6B, sint16) || ax != 1) {
 			// loc_66E2AE
-			RCT2_GLOBAL(0x013573DC, sint32) = 10000;
+			RCT2_GLOBAL(0x013573DC, sint32) -= 10000;
 			if (RCT2_GLOBAL(0x013573DC, sint32) >= 0)
 				RCT2_GLOBAL(0x013573DC, sint32) = -RCT2_GLOBAL(0x013573DC, sint32);
 		}
@@ -76,7 +78,7 @@ void news_item_update_current()
 			ax--;
 			if (ax != RCT2_GLOBAL(0x009DEA69, sint16)) {
 				// loc_66E2AE
-				RCT2_GLOBAL(0x013573DC, sint32) = 10000;
+				RCT2_GLOBAL(0x013573DC, sint32) -= 10000;
 				if (RCT2_GLOBAL(0x013573DC, sint32) >= 0)
 					RCT2_GLOBAL(0x013573DC, sint32) = -RCT2_GLOBAL(0x013573DC, sint32);
 			}

--- a/src/rct2.c
+++ b/src/rct2.c
@@ -72,7 +72,7 @@ int rct2_init()
 	RCT2_GLOBAL(0x009AC310, char*) = RCT2_GLOBAL(RCT2_ADDRESS_CMDLINE, char*);
 	get_system_time();
 	RCT2_GLOBAL(0x009DEA69, short) = RCT2_GLOBAL(RCT2_ADDRESS_OS_TIME_DAY, short);
-	RCT2_GLOBAL(0x009DEA6B, short) = RCT2_GLOBAL(RCT2_ADDRESS_OS_TIME_DAY, short);
+	RCT2_GLOBAL(0x009DEA6B, short) = RCT2_GLOBAL(RCT2_ADDRESS_OS_TIME_MONTH, short);
 	if (!rct2_init_directories())
 		return 0;
 

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -260,6 +260,7 @@ int scenario_load_and_play_from_path(const char *path)
 	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_COMPANY_VALUE, money32) = calculate_company_value();
 	RCT2_GLOBAL(0x013587D0, money32) = RCT2_GLOBAL(0x013573DC, money32) - RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_LOAN, money32);
 	RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONEY_ENCRYPTED, sint32) = ENCRYPT_MONEY(RCT2_GLOBAL(0x013573DC, sint32));
+
 	sub_69E869(); // (loan related)
 
 	strcpy((char*)RCT2_ADDRESS_SCENARIO_DETAILS, s6Info->details);


### PR DESCRIPTION
Fix #791.

Looks like this has always been masked by the title screen. Actual mistake was in rct2.c using the wrong address to copy the current month. Incidentally it would have worked correctly on the 1st of Jan, 2nd of Feb. (That would have been a pain to work out)

In future consider removing this code completely from news_item_update_current.