### PR TITLE
Fix ride breakdown

### DIFF
--- a/src/peep/peep.c
+++ b/src/peep/peep.c
@@ -1927,7 +1927,7 @@ static void peep_update(rct_peep *peep)
 			RCT2_CALLPROC_X(0x006C0CB8, 0, 0, 0, 0, (int)peep, 0, 0);
 			break;
 		case PEEP_STATE_FIXING:
-			RCT2_CALLPROC_X(0x006C0E8B, 0, 0, 0, 0, (int)peep, 0, 0);
+			RCT2_CALLPROC_X(0x006C0E8B, stepsToTake, 0, 0, 0, (int)peep, 0, 0);
 			break;
 		case PEEP_STATE_BUYING:
 			peep_update_buying(peep);

--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -1319,6 +1319,7 @@ static void ride_breakdown_update(int rideIndex)
 			ride->var_19C +
 			ride->var_19D +
 			ride->var_19E +
+			ride->var_19F +
 			ride->var_1A0 +
 			ride->var_1A2 +
 			ride->var_1A3;
@@ -1355,11 +1356,12 @@ static void ride_breakdown_update(int rideIndex)
 		agePenalty = ax >> 2;
 		break;
 	case 3:
+	case 4:
 		agePenalty = ax >> 1;
 		break;
-	case 4:
 	case 5:
 	case 6:
+	case 7:
 		agePenalty = ax >> 0;
 		break;
 	default:


### PR DESCRIPTION
Fix issue causing rides to not increase reliability when fixed. 
Also small fix to breakdown creation messages to match assembly.
Fixes #851.