### PR TITLE
Fix ghost entrances

### DIFF
--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -200,7 +200,7 @@ static void window_map_close()
 	rct2_free(RCT2_GLOBAL(RCT2_ADDRESS_MAP_IMAGE_DATA, uint32*));
 	if ((RCT2_GLOBAL(RCT2_ADDRESS_INPUT_FLAGS, uint32) & INPUT_FLAG_TOOL_ACTIVE) &&
 		RCT2_GLOBAL(RCT2_ADDRESS_TOOL_WINDOWCLASS, uint8) == w->classification &&
-		RCT2_GLOBAL(RCT2_ADDRESS_TOOL_WIDGETINDEX, uint16) == w->number) {
+		RCT2_GLOBAL(RCT2_ADDRESS_TOOL_WINDOWNUMBER, uint16) == w->number) {
 		tool_cancel();
 	}
 }


### PR DESCRIPTION
Caused by tool_cancel not being called due to comparing widgetIndex with window number instead of window number with window number.

Fixes #859.