### PR TITLE
Fix cursor

### DIFF
--- a/src/windows/scenery.c
+++ b/src/windows/scenery.c
@@ -690,9 +690,11 @@ static void window_scenery_update(rct_window *w)
 
 	gfx_invalidate_screen();
 	
-	if (!window_scenery_is_scenery_tool_active())
+	if (!window_scenery_is_scenery_tool_active()){
 		window_close(w);
-	
+		return;
+	}
+
 	if (window_scenery_is_repaint_scenery_tool_on == 1) { // the repaint scenery tool is active
 		RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TOOL, uint8) = 0x17;
 	} else {


### PR DESCRIPTION
Fixes #877
Fixes the cursor not changing when switching between scenery and other windows.
Issue was caused by missing a return and then proceeding to reset the cursor at a window update.