### PR TITLE
Don't scroll the window if it lost keyboard focus

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -1302,6 +1302,10 @@ void game_handle_edge_scroll()
 	if (mainWindow->viewport == NULL)
 		return;
 
+	uint32 window_flags = SDL_GetWindowFlags(gWindow);
+	if ((window_flags & SDL_WINDOW_INPUT_FOCUS) == 0)
+		return;
+
 	scrollX = 0;
 	scrollY = 0;
 


### PR DESCRIPTION
Partial solve for #695. Game will now stop scrolling when you click on other window, alt-tab etc.

(I'm not sure if `SDL_GetWindowFlags` should be wrapped in a function in platform.c)