### PR TITLE
Removed accidental call to original code in decompiled function

### DIFF
--- a/src/windows/staff.c
+++ b/src/windows/staff.c
@@ -1240,7 +1240,7 @@ void window_staff_overview_viewport_init_wrapper(){
 
 /* rct2: 0x006BEDA3 */
 void window_staff_viewport_init(rct_window* w){
-	RCT2_CALLPROC_X(0x006BEDA3, 0, 0, 0, 0, (int)w, 0, 0);
+	//RCT2_CALLPROC_X(0x006BEDA3, 0, 0, 0, 0, (int)w, 0, 0);
 
 	if (w->page != WINDOW_STAFF_OVERVIEW) return;
 


### PR DESCRIPTION
It was causing the staff window viewport to be recreated every frame.