### PR TITLE
Fixed build warning for implicit declaration

### DIFF
--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -18,9 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
 
-#ifdef _MSC_VER
 #include <time.h>
-#endif
 #include <argparse/argparse.h>
 #include "addresses.h"
 #include "cmdline.h"


### PR DESCRIPTION
Is there a reason for the `#ifdef _MSC_VER` here? On Mac OS X (and I presume *nices) this creates an implicit declaration warning for using the functions from `time.h`, so including it here solves this.

Maybe I'm missing something here, but it doesn't seem like this will be a functional change for *nix builds (unless it's not guaranteed that `time.h` exists?).