### PR TITLE
Fix "research group" being displayed when no item is selected

### DIFF
--- a/src/windows/editor_inventions_list.c
+++ b/src/windows/editor_inventions_list.c
@@ -339,7 +339,7 @@ static rct_research_item *window_editor_inventions_list_get_item_from_scroll_y(i
 		researchItem++;
 	}
 
-	for (; researchItem->entryIndex != RESEARCHED_ITEMS_SEPERATOR || researchItem->entryIndex == RESEARCHED_ITEMS_END; researchItem++) {
+	for (; researchItem->entryIndex != RESEARCHED_ITEMS_SEPERATOR && researchItem->entryIndex != RESEARCHED_ITEMS_END; researchItem++) {
 		y -= 10;
 		if (y < 0)
 			return researchItem;


### PR DESCRIPTION
Screenshot of the bug:

![2015-03-15_23-40-01](https://cloud.githubusercontent.com/assets/4729533/6666440/ba31343a-cbe4-11e4-83f4-85ce455a5c68.png)
