### PR TITLE
Fix negative ride ages

### DIFF
--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -5877,10 +5877,10 @@ static void window_ride_customer_paint()
 	y += 2;
 
 	// Age
+	//Reset build date to current if it's in the future
+	ride->build_date=min(ride->build_date,RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, uint16));
+
 	age = (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, uint16) - ride->build_date) / 8;
-	if (age < 0) {
-		age +=8192;
-	}
 	stringId = age == 0 ?
 		STR_BUILT_THIS_YEAR :
 		age == 1 ?

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -5878,6 +5878,9 @@ static void window_ride_customer_paint()
 
 	// Age
 	age = (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, uint16) - ride->build_date) / 8;
+	if (age < 0) {
+		age +=8192;
+	}
 	stringId = age == 0 ?
 		STR_BUILT_THIS_YEAR :
 		age == 1 ?

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -5877,10 +5877,8 @@ static void window_ride_customer_paint()
 	y += 2;
 
 	// Age
-	//Reset build date to current if it's in the future
-	ride->build_date=min(ride->build_date,RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, uint16));
-
-	age = (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, uint16) - ride->build_date) / 8;
+	//If the ride has a build date that is in the future, show it as built this year.
+	age = max((RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, uint16) - ride->build_date) / 8, 0);
 	stringId = age == 0 ?
 		STR_BUILT_THIS_YEAR :
 		age == 1 ?


### PR DESCRIPTION
Closes #921.

This stops rides having a negative age in the ride window.

Although this restores vanilla RCT2 behaviour, an age of -12 is arguably correct, because a ride that was built in year 13 in a park that has its date reset to year 1 isn't actually 8180 years old. Whether -12 or 8180 is more correct is a matter of debate, though I think it would be best if rides built in the future would simply get their build date reset to the current date when the game encounters one.