### PR TITLE
Add /MP flag to enable multiprocess compilation

### DIFF
--- a/projects/openrct2.vcxproj
+++ b/projects/openrct2.vcxproj
@@ -288,6 +288,7 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_CONFIG_H;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ObjectFileName>$(IntDir)fake\%(RelativeDir)</ObjectFileName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
On my computer, it speeds up full rebuild by a factor of 2. Probably won't do a difference on single-core CPUs.

The option is not enabled by default as it's incompatible with several other options (you can see the list [here](https://msdn.microsoft.com/en-us/library/bb385193.aspx). We don't use any of these and if someone wanted to use them, VS automatically ignores /MP.