### PR TITLE
Wipe cache on clean; fix install typo

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -3,8 +3,5 @@
 set -ev
 
 sudo rm -rf /usr/local/cross-tools/i686-w64-mingw32
-#rm -rf .cache
-rm -rf .cache/*.patch
-rm -rf .cache/SDL2-2.0.3
-rm -rf .cache/i686-w64-mingw32-pkg-config
+rm -rf .cache
 rm -rf build

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ if [[ `uname` == "Darwin" ]]; then
     if [[ ! -f $cachedir/$mingw_tar ]]; then
         wget "https://downloads.sourceforge.net/project/mingw-w64/Toolchains targetting Win32/Automated Builds/$mingw_tar" --output-document $cachedir/$mingw_tar
     fi
-    if [[ ! -d $ming_path ]]; then
+    if [[ ! -d "$mingw_path" ]]; then
 
         pushd /usr/local/
             sudo mkdir $mingw_name


### PR DESCRIPTION
Just tried installing OpenRCT2 and it *almost* worked perfectly! The one problem was I downloaded a corrupted .tgz file, and clean didn't actually delete it. 

The goal of `clean` should be to wipe everything, I believe, we could probably introduce some sort of flag to skip the big re-downloads, if they are a pain.