### PR TITLE
Name reliability variables

### DIFF
--- a/src/management/finance.c
+++ b/src/management/finance.c
@@ -127,7 +127,7 @@ void finance_pay_ride_upkeep()
 	FOR_ALL_RIDES(i, ride) {
 		if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)) {
 			ride->build_date = RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, uint16);
-			ride->var_196 = 25855; // durability?
+			ride->reliability = RIDE_INITIAL_RELIABILITY;
 
 		}
 		if (ride->status != RIDE_STATUS_CLOSED && !(RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) & PARK_FLAGS_NO_MONEY)) {

--- a/src/ride/ride.h
+++ b/src/ride/ride.h
@@ -218,7 +218,8 @@ typedef struct {
 			ride_rating nausea;		// 0x144
 		};
 	};
-	uint16 reliability;				// 0x146
+	// Max price customers will pay before they think the ride is bad value
+	uint16 fair_value;				// 0x146
 	uint16 var_148;
 	uint8 satisfaction;				// 0x14A
 	uint8 satisfaction_time_out;	// 0x14B
@@ -253,9 +254,13 @@ typedef struct {
 	uint8 broken_car;				// 0x192
 	uint8 breakdown_reason;			// 0x193
 	money16 price_secondary;		// 0x194
-	uint16 var_196;
-	// used in computing excitement, nausea, etc
-	uint8 var_198;
+	// Starts at RIDE_INITIAL_RELIABILITY and decreases from there. Right shift
+	// this number by 8 to get a reliability percentage 0-100
+	uint16 reliability;
+	// Small constant used to increase the unreliability as the game continues,
+	// making breakdowns more and more likely.
+	uint8 unreliability_factor;
+	// Down time
 	uint8 var_199;
 	uint8 inspection_interval;		// 0x19A
 	uint8 last_inspection;			// 0x19B
@@ -661,7 +666,8 @@ enum {
 #define MAX_RIDES 255
 
 #define MAX_RIDE_MEASUREMENTS 8
-#define RIDE_RELIABILITY_UNDEFINED 0xFFFF
+#define RIDE_FAIR_VALUE_UNDEFINED 0xFFFF
+#define RIDE_INITIAL_RELIABILITY ((100 << 8) - 1)
 
 #define STATION_DEPART_FLAG (1 << 7)
 #define STATION_DEPART_MASK (~STATION_DEPART_FLAG)

--- a/src/ride/ride.h
+++ b/src/ride/ride.h
@@ -218,8 +218,7 @@ typedef struct {
 			ride_rating nausea;		// 0x144
 		};
 	};
-	// Max price customers will pay before they think the ride is bad value
-	uint16 fair_value;				// 0x146
+	uint16 value;					// 0x146
 	uint16 var_148;
 	uint8 satisfaction;				// 0x14A
 	uint8 satisfaction_time_out;	// 0x14B
@@ -666,7 +665,7 @@ enum {
 #define MAX_RIDES 255
 
 #define MAX_RIDE_MEASUREMENTS 8
-#define RIDE_FAIR_VALUE_UNDEFINED 0xFFFF
+#define RIDE_VALUE_UNDEFINED 0xFFFF
 #define RIDE_INITIAL_RELIABILITY ((100 << 8) - 1)
 
 #define STATION_DEPART_FLAG (1 << 7)

--- a/src/ride/ride_ratings.c
+++ b/src/ride/ride_ratings.c
@@ -49,7 +49,7 @@ static void ride_ratings_update_state_4();
 static void ride_ratings_update_state_5();
 static void loc_6B5BB2();
 static void ride_ratings_calculate(rct_ride *ride);
-static void ride_ratings_fair_value_calculate(rct_ride *ride);
+static void ride_ratings_calculate_value(rct_ride *ride);
 
 static int sub_6C6402(rct_map_element *mapElement, int *x, int *y, int *z)
 {
@@ -283,7 +283,7 @@ static void ride_ratings_update_state_3()
 
 	ride_ratings_calculate(ride);
 	RCT2_CALLPROC_X(0x00655F64, 0, 0, 0, 0, 0, (int)ride, 0);
-	ride_ratings_fair_value_calculate(ride);
+	ride_ratings_calculate_value(ride);
 
 	window_invalidate_by_number(WC_RIDE, _rideRatingsCurrentRide);
 	_rideRatingsState = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
@@ -372,7 +372,7 @@ static void ride_ratings_calculate(rct_ride *ride)
 	}
 }
 
-static void ride_ratings_fair_value_calculate(rct_ride *ride)
+static void ride_ratings_calculate_value(rct_ride *ride)
 {
 	rct_ride *ride2;
 	int i, otherRidesOfSameType;
@@ -380,7 +380,7 @@ static void ride_ratings_fair_value_calculate(rct_ride *ride)
 	if (ride->excitement == (ride_rating)0xFFFF)
 		return;
 
-	int fair_value =
+	int value =
 		(((ride->excitement * RCT2_GLOBAL(0x0097CD1E + (ride->type * 6), sint16)) * 32) >> 15) +
 		(((ride->intensity  * RCT2_GLOBAL(0x0097CD20 + (ride->type * 6), sint16)) * 32) >> 15) +
 		(((ride->nausea     * RCT2_GLOBAL(0x0097CD22 + (ride->type * 6), sint16)) * 32) >> 15);
@@ -389,19 +389,19 @@ static void ride_ratings_fair_value_calculate(rct_ride *ride)
 
 	// New ride reward
 	if (monthsOld <= 12) {
-		fair_value += 10;
+		value += 10;
 		if (monthsOld <= 4)
-			fair_value += 20;
+			value += 20;
 	}
 
 	// Old ride penalty
-	if (monthsOld >= 40) fair_value -= fair_value / 4;
-	if (monthsOld >= 64) fair_value -= fair_value / 4;
+	if (monthsOld >= 40) value -= value / 4;
+	if (monthsOld >= 64) value -= value / 4;
 	if (monthsOld < 200) {
-		if (monthsOld >= 88) fair_value -= fair_value / 4;
-		if (monthsOld >= 104) fair_value -= fair_value / 4;
-		if (monthsOld >= 120) fair_value -= fair_value / 2;
-		if (monthsOld >= 128) fair_value -= fair_value / 2;
+		if (monthsOld >= 88) value -= value / 4;
+		if (monthsOld >= 104) value -= value / 4;
+		if (monthsOld >= 120) value -= value / 2;
+		if (monthsOld >= 128) value -= value / 2;
 	}
 
 	// Other ride of same type penalty
@@ -411,9 +411,9 @@ static void ride_ratings_fair_value_calculate(rct_ride *ride)
 			otherRidesOfSameType++;
 	}
 	if (otherRidesOfSameType > 1)
-		fair_value -= fair_value / 4;
+		value -= value / 4;
 
-	ride->fair_value = max(0, fair_value);
+	ride->value = max(0, value);
 }
 
 /**

--- a/src/windows/new_campaign.c
+++ b/src/windows/new_campaign.c
@@ -100,13 +100,13 @@ static void* window_new_campaign_events[] = {
 uint8 window_new_campaign_rides[MAX_RIDES];
 uint8 window_new_campaign_shop_items[64];
 
-int ride_reliability_compare(const void *a, const void *b)
+int ride_fair_value_compare(const void *a, const void *b)
 {
 	rct_ride *rideA, *rideB;
 
 	rideA = GET_RIDE(*((uint8*)a));
 	rideB = GET_RIDE(*((uint8*)b));
-	return rideB->reliability - rideA->reliability;
+	return rideB->fair_value - rideA->fair_value;
 }
 
 int ride_name_compare(const void *a, const void *b)
@@ -179,7 +179,7 @@ void window_new_campaign_open(sint16 campaignType)
 
 	// Take top 40 most reliable rides
 	if (numApplicableRides > 40) {
-		qsort(window_new_campaign_rides, countof(window_new_campaign_rides), sizeof(uint8), ride_reliability_compare);
+		qsort(window_new_campaign_rides, countof(window_new_campaign_rides), sizeof(uint8), ride_fair_value_compare);
 		numApplicableRides = 40;
 	}
 

--- a/src/windows/new_campaign.c
+++ b/src/windows/new_campaign.c
@@ -100,13 +100,13 @@ static void* window_new_campaign_events[] = {
 uint8 window_new_campaign_rides[MAX_RIDES];
 uint8 window_new_campaign_shop_items[64];
 
-int ride_fair_value_compare(const void *a, const void *b)
+int ride_value_compare(const void *a, const void *b)
 {
 	rct_ride *rideA, *rideB;
 
 	rideA = GET_RIDE(*((uint8*)a));
 	rideB = GET_RIDE(*((uint8*)b));
-	return rideB->fair_value - rideA->fair_value;
+	return rideB->value - rideA->value;
 }
 
 int ride_name_compare(const void *a, const void *b)
@@ -179,7 +179,7 @@ void window_new_campaign_open(sint16 campaignType)
 
 	// Take top 40 most reliable rides
 	if (numApplicableRides > 40) {
-		qsort(window_new_campaign_rides, countof(window_new_campaign_rides), sizeof(uint8), ride_fair_value_compare);
+		qsort(window_new_campaign_rides, countof(window_new_campaign_rides), sizeof(uint8), ride_value_compare);
 		numApplicableRides = 40;
 	}
 

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -3434,7 +3434,7 @@ static void window_ride_maintenance_paint()
 	x = w->x + widget->left + 4;
 	y = w->y + widget->top + 4;
 
-	reliability = ride->var_196 >> 8;
+	reliability = ride->reliability >> 8;
 	gfx_draw_string_left(dpi, STR_RELIABILITY_LABEL_1757, &reliability, 0, x, y);
 	window_ride_maintenance_draw_bar(w, dpi, x + 103, y, max(10, reliability), 14);
 	y += 11;

--- a/src/windows/ride_list.c
+++ b/src/windows/ride_list.c
@@ -507,7 +507,7 @@ static void window_ride_list_scrollpaint()
 		case INFORMATION_TYPE_RELIABILITY:
 			// edx = RCT2_GLOBAL(0x009ACFA4 + (ride->var_001 * 4), uint32);
 
-			RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride->var_196 >> 8;
+			RCT2_GLOBAL(0x013CE952 + 2, uint16) = ride->reliability >> 8;
 			formatSecondary = STR_RELIABILITY_LABEL;
 			break;
 		case INFORMATION_TYPE_DOWN_TIME:
@@ -661,7 +661,7 @@ static void window_ride_list_refresh_list(rct_window *w)
 		case INFORMATION_TYPE_RELIABILITY:
 			while (--current_list_position >= 0) {
 				otherRide = &g_ride_list[w->list_item_positions[current_list_position]];
-				if (ride->var_196 >> 8 <= otherRide->var_196 >> 8)
+				if (ride->reliability >> 8 <= otherRide->reliability >> 8)
 					break;
 
 				window_bubble_list_item(w, current_list_position);

--- a/src/world/park.c
+++ b/src/world/park.c
@@ -276,11 +276,11 @@ money32 calculate_ride_value(rct_ride *ride)
 {
 	if (ride->type == RIDE_TYPE_NULL)
 		return 0;
-	if (ride->reliability == 0xFFFF)
+	if (ride->fair_value == RIDE_FAIR_VALUE_UNDEFINED)
 		return 0;
 
-	// Reliability * (...)
-	return (ride->reliability * 10) * (
+	// Fair value * (...)
+	return (ride->fair_value * 10) * (
 		ride->var_124 + ride->var_126 + ride->var_128 + ride->var_12A +
 		ride->var_12C + ride->var_12E + ride->age + ride->running_cost +
 		ride->var_134 + ride->var_136 +
@@ -369,8 +369,8 @@ static int park_calculate_guest_generation_probability()
 		suggestedMaxGuests += RCT2_GLOBAL(0x0097D21E + (ride->type * 8), uint8);
 
 		// Add ride value
-		if (ride->reliability != RIDE_RELIABILITY_UNDEFINED) {
-			int rideValue = ride->reliability - ride->price;
+		if (ride->fair_value != RIDE_FAIR_VALUE_UNDEFINED) {
+			int rideValue = ride->fair_value - ride->price;
 			if (rideValue > 0)
 				totalRideValue += rideValue * 2;
 		}

--- a/src/world/park.c
+++ b/src/world/park.c
@@ -276,11 +276,11 @@ money32 calculate_ride_value(rct_ride *ride)
 {
 	if (ride->type == RIDE_TYPE_NULL)
 		return 0;
-	if (ride->fair_value == RIDE_FAIR_VALUE_UNDEFINED)
+	if (ride->value == RIDE_VALUE_UNDEFINED)
 		return 0;
 
 	// Fair value * (...)
-	return (ride->fair_value * 10) * (
+	return (ride->value * 10) * (
 		ride->var_124 + ride->var_126 + ride->var_128 + ride->var_12A +
 		ride->var_12C + ride->var_12E + ride->age + ride->running_cost +
 		ride->var_134 + ride->var_136 +
@@ -369,8 +369,8 @@ static int park_calculate_guest_generation_probability()
 		suggestedMaxGuests += RCT2_GLOBAL(0x0097D21E + (ride->type * 8), uint8);
 
 		// Add ride value
-		if (ride->fair_value != RIDE_FAIR_VALUE_UNDEFINED) {
-			int rideValue = ride->fair_value - ride->price;
+		if (ride->value != RIDE_VALUE_UNDEFINED) {
+			int rideValue = ride->value - ride->price;
 			if (rideValue > 0)
 				totalRideValue += rideValue * 2;
 		}


### PR DESCRIPTION
- Rename var_146 to value (it is not reliability)
- Add a helper method get_age_penalty which computes the age penalty for
  a ride.
- Adds a constant for a ride's initial reliability
- Names a subroutine