### PR TITLE
Fix on ride photo and station lights

### DIFF
--- a/src/ride/vehicle.c
+++ b/src/ride/vehicle.c
@@ -35,7 +35,7 @@ static void vehicle_update(rct_vehicle *vehicle);
 */
 void vehicle_update_sound_params(rct_vehicle* vehicle)
 {
-	if (!(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & 2) && (!(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & 4) || RCT2_GLOBAL(0x0141F570, uint8) == 6)) {
+	if (!(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_SCENARIO_EDITOR) && (!(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_DESIGNER) || RCT2_GLOBAL(0x0141F570, uint8) == 6)) {
 		if (vehicle->sound1_id != (uint8)-1 || vehicle->sound2_id != (uint8)-1) {
 			if (vehicle->sprite_left != 0x8000) {
 				RCT2_GLOBAL(0x009AF5A0, sint16) = vehicle->sprite_left;
@@ -549,10 +549,10 @@ void vehicle_update_all()
 	uint16 sprite_index;
 	rct_vehicle *vehicle;
 
-	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & 2)
+	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_SCENARIO_EDITOR)
 		return;
 
-	if ((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & 4) && RCT2_GLOBAL(0x0141F570, uint8) != 6)
+	if ((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_DESIGNER) && RCT2_GLOBAL(0x0141F570, uint8) != 6)
 		return;
 
 

--- a/src/world/map_animation.c
+++ b/src/world/map_animation.c
@@ -83,7 +83,7 @@ void map_animation_invalidate_all()
 			RCT2_GLOBAL(0x0138B580, uint16)--;
 			numAnimatedObjects--;
 			if (numAnimatedObjects > 0)
-				memmove(aobj, aobj + 1, numAnimatedObjects);
+				memmove(aobj, aobj + 1, numAnimatedObjects * sizeof(rct_map_animation));
 		} else {
 			numAnimatedObjects--;
 			aobj++;

--- a/src/world/map_animation.c
+++ b/src/world/map_animation.c
@@ -55,7 +55,8 @@ void map_animation_create(int type, int x, int y, int z)
 			continue;
 		if (aobj->baseZ != z)
 			continue;
-
+		if (aobj->type != type)
+			continue;
 		// Animation already exists
 		return;
 	}


### PR DESCRIPTION
I found the source of the station lights not changing. It was due to missing calls to ride_invalidate_station_start. I didn't bother changing the function for bumper rides as it doesn't look like it uses station lights if thats not the case it can easily be changed.

The on ride photos failing were due to a mistake in the map animation removal function. I'm surprised there were not more map animation problems.

Fixes #936 and #930.