### PR TITLE
Fix vehicle and graph tab of ride window and options window

### DIFF
--- a/src/localisation/localisation.c
+++ b/src/localisation/localisation.c
@@ -351,7 +351,7 @@ void format_date(char **dest, uint16 value)
 	(*dest)--;
 }
 
-void format_length(char **dest, uint16 value)
+void format_length(char **dest, sint16 value)
 {
 	rct_string_id stringId = 2733;
 

--- a/src/windows/editor_object_selection.c
+++ b/src/windows/editor_object_selection.c
@@ -214,7 +214,7 @@ void window_editor_object_selection_open()
 		400,
 		(uint32*)window_editor_object_selection_events,
 		WC_EDITOR_OBJECT_SELECTION,
-		WF_STICK_TO_FRONT
+		WF_10
 	);
 	window->widgets = window_editor_object_selection_widgets;
 

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -221,7 +221,7 @@ void window_options_open()
 	if (w != NULL)
 		return;
 
-	w = window_create_centred(WW, WH, (uint32*)window_options_events, WC_OPTIONS, 0);
+	w = window_create_centred(WW, WH, (uint32*)window_options_events, WC_OPTIONS, WF_STICK_TO_FRONT);
 	w->widgets = window_options_widgets;
 	w->enabled_widgets =
 		(1ULL << WIDX_CLOSE) |

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -221,7 +221,7 @@ void window_options_open()
 	if (w != NULL)
 		return;
 
-	w = window_create_centred(WW, WH, (uint32*)window_options_events, WC_OPTIONS, WF_STICK_TO_FRONT);
+	w = window_create_centred(WW, WH, (uint32*)window_options_events, WC_OPTIONS, 0);
 	w->widgets = window_options_widgets;
 	w->enabled_widgets =
 		(1ULL << WIDX_CLOSE) |

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -1408,6 +1408,12 @@ static void window_ride_set_page(rct_window *w, int page)
 	w->page = page;
 	w->frame_no = 0;
 	w->var_492 = 0;
+
+	if (page == WINDOW_RIDE_PAGE_VEHICLE){
+		// Reload the vehicle settings
+		RCT2_CALLPROC_X(0x006DD57D, 0, 0, 0, w->number, 0, 0, 0);
+	}
+
 	if (w->viewport != NULL) {
 		w->viewport->width = 0;
 		w->viewport = NULL;

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -5262,11 +5262,12 @@ static void window_ride_graphs_scrollpaint()
 
 		gfx_fill_rect(dpi, dpi->x, y, dpi->x + dpi->width - 1, y, colour);
 
+		sint16 scaled_yUnit = yUnit;
 		// Scale modifier
 		if (ax == 1420)
-			yUnit /= 2;
+			scaled_yUnit /= 2;
 
-		gfx_draw_string_left(dpi, ax, &yUnit, 0, w->scrolls[0].h_left + 1, y - 4);
+		gfx_draw_string_left(dpi, ax, &scaled_yUnit, 0, w->scrolls[0].h_left + 1, y - 4);
 	}
 
 	// Time marks

--- a/src/windows/title_scenarioselect.c
+++ b/src/windows/title_scenarioselect.c
@@ -116,7 +116,7 @@ void window_scenarioselect_open()
 		334,
 		(uint32*)window_scenarioselect_events,
 		WC_SCENARIO_SELECT,
-		WF_STICK_TO_FRONT | WF_10
+		WF_10
 	);
 	window->widgets = window_scenarioselect_widgets;
 	


### PR DESCRIPTION
Fixes #1016.
Looks like this little function was missed when reverseing this function.
Also fixed #1005.
Also fixed #1003 as well.