### PR TITLE
Fix land tool size staying in window after unselect land ownership tool

### DIFF
--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -378,6 +378,8 @@ static void window_map_mousedown(int widgetIndex, rct_window*w, rct_widget* widg
 	}
 	else if (widgetIndex == WIDX_SET_LAND_RIGHTS)
 	{
+		// When unselecting the land rights tool, reset the size so the number doesn't
+		// stay in the map window.
 		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = 1;
 	}
 }

--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -369,13 +369,16 @@ static void window_map_mouseup()
 */
 static void window_map_mousedown(int widgetIndex, rct_window*w, rct_widget* widget)
 {
-	// The normal map window doesn't have widget 8 or 9.
-	// I assume these widgets refer to the Scenario Editor's map window.
-	if (widgetIndex == 8) {
+	// These widgets all refer to the Scenario Editor's map window.
+	if (widgetIndex == WIDX_MAP_SIZE_SPINNER_UP) {
 		RCT2_CALLPROC_X(0x0068D641, 0, 0, 0, widgetIndex, (int)w, 0, 0);
 	}
-	else if (widgetIndex == 9) {
+	else if (widgetIndex == WIDX_MAP_SIZE_SPINNER_DOWN) {
 		RCT2_CALLPROC_X(0x0068D6B4, 0, 0, 0, widgetIndex, (int)w, 0, 0);
+	}
+	else if (widgetIndex == WIDX_SET_LAND_RIGHTS)
+	{
+		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = 1;
 	}
 }
 


### PR DESCRIPTION
When using the land ownership tool with a tool size larger than 7 (displaying a number), and then unselecting the tool, the number will stay in the window. This PR fixes that. It also uses the constants for the map size up/down buttons and updates the comment above it.