### PR TITLE
Scenery secondary colour bug

### DIFF
--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -1286,7 +1286,7 @@ static void window_top_toolbar_scenery_tool_down(short x, short y, rct_window* w
 
 				RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_STRING_ID, rct_string_id) = 1161;
 
-				int cost = game_do_command(cur_grid_x, ebx, cur_grid_y, parameter_2, GAME_COMMAND_15, RCT2_GLOBAL(0x00F64EC0, uint8), RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16));
+				int cost = game_do_command(cur_grid_x, ebx, cur_grid_y, parameter_2, GAME_COMMAND_15, RCT2_GLOBAL(0x00F64EC0, uint8) | (parameter_3 & 0xFFFF0000), RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16));
 
 
 				RCT2_GLOBAL(0x009A8C29, uint8) &= ~1;


### PR DESCRIPTION
Fix #1032 

Forgot to pass the colour variable to the create scenery command.