### PR TITLE
Textbox carot is now same color as text

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3460,3 +3460,10 @@ STR_5123    :Renew rides
 STR_5124    :No Six Flags
 STR_5125    :All destructable
 STR_5126    :Random title music
+STR_5127    :{SMALLFONT}{BLACK}Disable land elevation
+STR_5128    :Selection size
+STR_5129    :Enter selection size between 0 and 64
+STR_5130    :Enter selection size between 1 and 64
+STR_5131    :Enter selection size between 1 and 7
+STR_5132    :Map size
+STR_5133    :Enter map size between 50 and 256

--- a/src/windows/clear_scenery.c
+++ b/src/windows/clear_scenery.c
@@ -184,7 +184,9 @@ static void window_clear_scenery_textinput()
 		return;
 
 	size = strtol(text, &end, 10);
-	if (size >= 1 && size <= 7 && *end == '\0') {
+	if (*end == '\0') {
+		if (size < 1) size = 1;
+		if (size > 7) size = 7;
 		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = size;
 		window_invalidate(w);
 	}

--- a/src/windows/clear_scenery.c
+++ b/src/windows/clear_scenery.c
@@ -53,6 +53,8 @@ static void window_clear_scenery_mouseup();
 static void window_clear_scenery_update(rct_window *w);
 static void window_clear_scenery_invalidate();
 static void window_clear_scenery_paint();
+static void window_clear_scenery_textinput();
+static void window_clear_scenery_inputsize(rct_window *w);
 
 static void* window_clear_scenery_events[] = {
 	window_clear_scenery_close,
@@ -74,7 +76,7 @@ static void* window_clear_scenery_events[] = {
 	window_clear_scenery_emptysub,
 	window_clear_scenery_emptysub,
 	window_clear_scenery_emptysub,
-	window_clear_scenery_emptysub,
+	window_clear_scenery_textinput,
 	window_clear_scenery_emptysub,
 	window_clear_scenery_emptysub,
 	window_clear_scenery_emptysub,
@@ -99,7 +101,7 @@ void window_clear_scenery_open()
 
 	window = window_create(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_WIDTH, sint16) - 98, 29, 98, 67, (uint32*)window_clear_scenery_events, WC_CLEAR_SCENERY, 0);
 	window->widgets = window_clear_scenery_widgets;
-	window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_INCREMENT) | (1 << WIDX_DECREMENT);
+	window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_INCREMENT) | (1 << WIDX_DECREMENT) | (1 << WIDX_PREVIEW);
 	window_init_scroll_widgets(window);
 	window_push_others_below(window);
 
@@ -161,7 +163,36 @@ static void window_clear_scenery_mouseup()
 		// Invalidate the window
 		window_invalidate(w);
 		break;
+	case WIDX_PREVIEW:
+		window_clear_scenery_inputsize(w);
+		break;
 	}
+}
+
+static void window_clear_scenery_textinput()
+{
+	uint8 result;
+	short widgetIndex;
+	rct_window *w;
+	char *text;
+	int size;
+	char* end;
+
+	window_textinput_get_registers(w, widgetIndex, result, text);
+
+	if (widgetIndex != WIDX_PREVIEW || !result)
+		return;
+
+	size = strtol(text, &end, 10);
+	if (size >= 1 && size <= 7 && *end == '\0') {
+		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = size;
+		window_invalidate(w);
+	}
+}
+
+static void window_clear_scenery_inputsize(rct_window *w)
+{
+	window_text_input_open(w, WIDX_PREVIEW, 5128, 5131, STR_NONE, STR_NONE, 3);
 }
 
 /**

--- a/src/windows/land.c
+++ b/src/windows/land.c
@@ -36,17 +36,19 @@ enum WINDOW_LAND_WIDGET_IDX {
 	WIDX_INCREMENT,
 	WIDX_FLOOR,
 	WIDX_WALL,
+	WIDX_PAINTMODE,
 };
 
 static rct_widget window_land_widgets[] = {
 	{ WWT_FRAME,	0,	0,	97,	0,	125,	-1,			STR_NONE },						// panel / background
 	{ WWT_CAPTION,	0,	1,	96,	1,	14,		STR_LAND,	STR_WINDOW_TITLE_TIP },			// title bar
 	{ WWT_CLOSEBOX,	0,	85,	95,	2,	13,		824,		STR_CLOSE_WINDOW_TIP },			// close x button
-	{ WWT_IMGBTN,	0,	27,	70,	17,	48,		5503,		STR_NONE },						// preview box
-	{ WWT_TRNBTN,	1,	28,	43,	18,	33,		0x20000000 | SPR_LAND_TOOL_DECREASE,	STR_ADJUST_SMALLER_LAND_TIP },	// decrement size
-	{ WWT_TRNBTN,	1,	54,	69,	32,	47,		0x20000000 | SPR_LAND_TOOL_INCREASE,	STR_ADJUST_LARGER_LAND_TIP },	// increment size
+	{ WWT_IMGBTN,	0,	10,	53,	17,	48,		5503,		STR_NONE },						// preview box
+	{ WWT_TRNBTN,	1,	11,	26,	18,	33,		0x20000000 | SPR_LAND_TOOL_DECREASE,	STR_ADJUST_SMALLER_LAND_TIP },	// decrement size
+	{ WWT_TRNBTN,	1,	37,	52,	32,	47,		0x20000000 | SPR_LAND_TOOL_INCREASE,	STR_ADJUST_LARGER_LAND_TIP },	// increment size
 	{ WWT_FLATBTN,	1,	2,	48,	75,	110,	0xFFFFFFFF,	STR_CHANGE_BASE_LAND_TIP },		// floor texture
 	{ WWT_FLATBTN,	1,	49,	95,	75,	110,	0xFFFFFFFF,	STR_CHANGE_VERTICAL_LAND_TIP },	// wall texture
+	{ WWT_FLATBTN,  1,	64,	87,	21,	44,		5173,		5127 }, // paint mode
 	{ WIDGETS_END },
 };
 
@@ -58,6 +60,9 @@ static void window_land_dropdown();
 static void window_land_update(rct_window *w);
 static void window_land_invalidate();
 static void window_land_paint();
+static void window_land_textinput();
+static void window_land_inputsize(rct_window *w);
+
 
 static void* window_land_events[] = {
 	window_land_close,
@@ -79,7 +84,7 @@ static void* window_land_events[] = {
 	window_land_emptysub,
 	window_land_emptysub,
 	window_land_emptysub,
-	window_land_emptysub,
+	window_land_textinput,
 	window_land_emptysub,
 	window_land_emptysub,
 	window_land_emptysub,
@@ -130,12 +135,15 @@ void window_land_open()
 		(1 << WIDX_DECREMENT) |
 		(1 << WIDX_INCREMENT) |
 		(1 << WIDX_FLOOR) |
-		(1 << WIDX_WALL);
+		(1 << WIDX_WALL) |
+		(1 << WIDX_PAINTMODE) |
+		(1 << WIDX_PREVIEW);
 	window_init_scroll_widgets(window);
 	window_push_others_below(window);
 
 	RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_SURFACE, uint8) = 255;
 	RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) = 255;
+	LandPaintMode = false;
 	_selectedFloorTexture = 0;
 	_selectedWallTexture = 0;
 	RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) = MONEY32_UNDEFINED;
@@ -200,6 +208,13 @@ static void window_land_mouseup()
 		// Invalidate the window
 		window_invalidate(w);
 		break;
+	case WIDX_PAINTMODE:
+		LandPaintMode ^= 1;
+		window_invalidate(w);
+		break;
+	case WIDX_PREVIEW:
+		window_land_inputsize(w);
+		break;
 	}
 }
 
@@ -245,6 +260,9 @@ static void window_land_mousedown(int widgetIndex, rct_window*w, rct_widget* wid
 			47, 36,
 			gAppropriateImageDropdownItemsPerRow[4]
 		);
+		break;
+	case WIDX_PREVIEW:
+		window_land_inputsize(w);
 		break;
 	}
 }
@@ -297,6 +315,32 @@ static void window_land_dropdown()
 	}
 }
 
+static void window_land_textinput()
+{
+	uint8 result;
+	short widgetIndex;
+	rct_window *w;
+	char *text;
+	int size;
+	char* end;
+
+	window_textinput_get_registers(w, widgetIndex, result, text);
+
+	if (widgetIndex != WIDX_PREVIEW || !result)
+		return;
+
+	size = strtol(text, &end, 10);
+	if (size >= 0 && size <= 64 && *end == '\0') {
+		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = size;
+		window_invalidate(w);
+	}
+}
+
+static void window_land_inputsize(rct_window *w)
+{
+	window_text_input_open(w, WIDX_PREVIEW, 5128, 5129, STR_NONE, STR_NONE, 3);
+}
+
 /**
  *
  *  rct2: 0x00664272
@@ -323,6 +367,8 @@ static void window_land_invalidate()
 		w->pressed_widgets |= (1 << WIDX_FLOOR);
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) != 255)
 		w->pressed_widgets |= (1 << WIDX_WALL);
+	if (LandPaintMode != 0)
+		w->pressed_widgets |= (1 << WIDX_PAINTMODE);
 
 	window_land_widgets[WIDX_FLOOR].image = SPR_FLOOR_TEXTURE_GRASS + _selectedFloorTexture;
 	window_land_widgets[WIDX_WALL].image = SPR_WALL_TEXTURE_ROCK + _selectedWallTexture;
@@ -358,6 +404,7 @@ static void window_land_paint()
 		gfx_draw_string_centred(dpi, 3165, x, y - 2, 0, (void*)0x013CE952);
 	}
 
+	x = w->x + (window_land_widgets[WIDX_PREVIEW].left + window_land_widgets[WIDX_PREVIEW].right) / 2 + 17;
 	y = w->y + window_land_widgets[WIDX_PREVIEW].bottom + 5;
 
 	// Draw raise cost amount

--- a/src/windows/land.c
+++ b/src/windows/land.c
@@ -330,7 +330,9 @@ static void window_land_textinput()
 		return;
 
 	size = strtol(text, &end, 10);
-	if (size >= 0 && size <= 64 && *end == '\0') {
+	if (*end == '\0') {
+		if (size < 0) size = 0;
+		if (size > 64) size = 64;
 		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = size;
 		window_invalidate(w);
 	}

--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -95,6 +95,9 @@ static void window_map_invalidate();
 static void window_map_paint();
 static void window_map_scrollpaint();
 static void window_map_tooltip();
+static void window_map_textinput();
+static void window_map_inputsize_land(rct_window *w);
+static void window_map_inputsize_map(rct_window *w);
 
 static void window_map_set_bounds(rct_window* w);
 
@@ -121,7 +124,7 @@ static void* window_map_events[] = {
 	window_map_scrollmousedown,
 	window_map_scrollmousedown,
 	window_map_emptysub,
-	window_map_emptysub,
+	window_map_textinput,
 	window_map_emptysub,
 	window_map_emptysub,
 	window_map_tooltip,
@@ -160,8 +163,10 @@ void window_map_open()
 		(1 << WIDX_CLOSE) |
 		(1 << WIDX_PEOPLE_TAB) |
 		(1 << WIDX_RIDES_TAB) |
+		(1 << WIDX_MAP_SIZE_SPINNER) |
 		(1 << WIDX_MAP_SIZE_SPINNER_UP) |
 		(1 << WIDX_MAP_SIZE_SPINNER_DOWN) |
+		(1 << WIDX_LAND_TOOL) |
 		(1 << WIDX_LAND_TOOL_SMALLER) |
 		(1 << WIDX_LAND_TOOL_LARGER) |
 		(1 << WIDX_SET_LAND_RIGHTS) |
@@ -345,6 +350,12 @@ static void window_map_mouseup()
 		show_land_rights();
 		show_construction_rights();
 		break;
+	case WIDX_LAND_TOOL:
+		window_map_inputsize_land(var_w);
+		break;
+	case WIDX_MAP_SIZE_SPINNER:
+		window_map_inputsize_map(var_w);
+		break;
 
 	default:
 		if (var_idx >= WIDX_PEOPLE_TAB && var_idx <= WIDX_RIDES_TAB)
@@ -382,6 +393,53 @@ static void window_map_mousedown(int widgetIndex, rct_window*w, rct_widget* widg
 		// stay in the map window.
 		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = 1;
 	}
+}
+
+static void window_map_textinput()
+{
+	uint8 result;
+	short widgetIndex;
+	rct_window *w;
+	char *text;
+	int size;
+	char* end;
+
+	window_textinput_get_registers(w, widgetIndex, result, text);
+
+	if (result) {
+		if (widgetIndex == WIDX_LAND_TOOL) {
+			size = strtol(text, &end, 10);
+			if (size >= 1 && size <= 64 && *end == '\0') {
+				RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = size;
+				window_invalidate(w);
+			}
+		}
+		else if (widgetIndex == WIDX_MAP_SIZE_SPINNER) {
+			size = strtol(text, &end, 10);
+			if (size >= 50 && size <= 256 && *end == '\0') {
+				int currentSize = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SIZE, uint16);
+				while (size < currentSize) {
+					RCT2_CALLPROC_X(0x0068D6B4, 0, 0, 0, widgetIndex, (int)w, 0, 0);
+					currentSize--;
+				}
+				while (size > currentSize) {
+					RCT2_CALLPROC_X(0x0068D641, 0, 0, 0, widgetIndex, (int)w, 0, 0);
+					currentSize++;
+				}
+				window_invalidate(w);
+			}
+		}
+	}
+}
+
+static void window_map_inputsize_land(rct_window *w)
+{
+	window_text_input_open(w, WIDX_LAND_TOOL, 5128, 5130, STR_NONE, STR_NONE, 3);
+}
+
+static void window_map_inputsize_map(rct_window *w)
+{
+	window_text_input_open(w, WIDX_MAP_SIZE_SPINNER, 5132, 5133, STR_NONE, STR_NONE, 4);
 }
 
 /**

--- a/src/windows/map.c
+++ b/src/windows/map.c
@@ -409,14 +409,18 @@ static void window_map_textinput()
 	if (result) {
 		if (widgetIndex == WIDX_LAND_TOOL) {
 			size = strtol(text, &end, 10);
-			if (size >= 1 && size <= 64 && *end == '\0') {
+			if (*end == '\0') {
+				if (size < 1) size = 1;
+				if (size > 64) size = 64;
 				RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = size;
 				window_invalidate(w);
 			}
 		}
 		else if (widgetIndex == WIDX_MAP_SIZE_SPINNER) {
 			size = strtol(text, &end, 10);
-			if (size >= 50 && size <= 256 && *end == '\0') {
+			if (*end == '\0') {
+				if (size < 50) size = 50;
+				if (size > 256) size = 256;
 				int currentSize = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SIZE, uint16);
 				while (size < currentSize) {
 					RCT2_CALLPROC_X(0x0068D6B4, 0, 0, 0, widgetIndex, (int)w, 0, 0);

--- a/src/windows/text_input.c
+++ b/src/windows/text_input.c
@@ -249,7 +249,11 @@ static void window_text_input_paint(){
 			}
 
 			if (w->frame_no > 15){
-				gfx_fill_rect(dpi, cur_x, y + 9, cur_x + width, y + 9, w->colours[1]);
+				uint8 eax;
+				eax = RCT2_ADDRESS(0x0141FC4A, uint8)[w->colours[1] * 8];
+				eax = eax << 16;
+				eax = eax | RCT2_ADDRESS(0x0141FC48, uint8)[w->colours[1] * 8];
+				gfx_fill_rect(dpi, cur_x, y + 9, cur_x + width, y + 9, (eax & 0xFF) + 5);
 			}
 
 			cur_drawn++;

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -1459,7 +1459,11 @@ static void window_top_toolbar_tool_update()
 		RCT2_CALLPROC_X(0x0068E213, x, y, 0, widgetIndex, (int)w, 0, 0);
 		break;
 	case WIDX_LAND:
-		RCT2_CALLPROC_X(0x00664280, x, y, 0, widgetIndex, (int)w, 0, 0);
+		if (LandPaintMode)
+			// Use the method that allows dragging the selection area
+			RCT2_CALLPROC_X(0x0068E213, x, y, 0, widgetIndex, (int)w, 0, 0);
+		else
+			RCT2_CALLPROC_X(0x00664280, x, y, 0, widgetIndex, (int)w, 0, 0);
 		break;
 	case WIDX_WATER:
 		RCT2_CALLPROC_X(0x006E6BDC, x, y, 0, widgetIndex, (int)w, 0, 0);
@@ -1741,7 +1745,25 @@ static void window_top_toolbar_tool_drag()
 		RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TOOL, uint8) = 12;
 		break;
 	case WIDX_LAND:
-		window_top_toolbar_land_tool_drag(x, y);
+		// Custom setting to only change land style instead of raising or lowering land
+		if (LandPaintMode) {
+			if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16)&(1 << 0)){
+				RCT2_GLOBAL(RCT2_ADDRESS_GAME_COMMAND_ERROR_STRING_ID, rct_string_id) = 1387;
+				game_do_command(
+					RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, uint16),
+					1,
+					RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, uint16),
+					RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_SURFACE, uint8) | (RCT2_GLOBAL(RCT2_ADDRESS_SELECTED_TERRAIN_EDGE, uint8) << 8),
+					GAME_COMMAND_CHANGE_SURFACE_STYLE,
+					RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, uint16),
+					RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, uint16)
+					);
+				// The tool is set to 12 here instead of 3 so that the dragging cursor is not the elevation change cursor
+				RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TOOL, uint8) = 12;
+			}
+		} else {
+			window_top_toolbar_land_tool_drag(x, y);
+		}
 		break;
 	case WIDX_WATER:
 		window_top_toolbar_water_tool_drag(x, y);
@@ -1862,7 +1884,6 @@ void top_toolbar_view_menu_dropdown(short dropdownIndex) {
 		window_invalidate(w);
 	}
 }
-
 
 /**
  *

--- a/src/windows/water.c
+++ b/src/windows/water.c
@@ -53,6 +53,8 @@ static void window_water_mouseup();
 static void window_water_update();
 static void window_water_invalidate();
 static void window_water_paint();
+static void window_water_textinput();
+static void window_water_inputsize(rct_window *w);
 
 static void* window_water_events[] = {
 	window_water_close,
@@ -74,7 +76,7 @@ static void* window_water_events[] = {
 	window_water_emptysub,
 	window_water_emptysub,
 	window_water_emptysub,
-	window_water_emptysub,
+	window_water_textinput,
 	window_water_emptysub,
 	window_water_emptysub,
 	window_water_emptysub,
@@ -99,7 +101,7 @@ void window_water_open()
 
 	window = window_create(RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_WIDTH, sint16) - 76, 29, 76, 77, (uint32*)window_water_events, WC_WATER, 0);
 	window->widgets = window_water_widgets;
-	window->enabled_widgets = 0x04 | 0x10 | 0x20;
+	window->enabled_widgets = (1 << WIDX_CLOSE) | (1 << WIDX_DECREMENT) | (1 << WIDX_INCREMENT) | (1 << WIDX_PREVIEW);
 	window_init_scroll_widgets(window);
 	window_push_others_below(window);
 
@@ -162,7 +164,36 @@ static void window_water_mouseup()
 		// Invalidate the window
 		window_invalidate(w);
 		break;
+	case WIDX_PREVIEW:
+		window_water_inputsize(w);
+		break;
 	}
+}
+
+static void window_water_textinput()
+{
+	uint8 result;
+	short widgetIndex;
+	rct_window *w;
+	char *text;
+	int size;
+	char* end;
+
+	window_textinput_get_registers(w, widgetIndex, result, text);
+
+	if (widgetIndex != WIDX_PREVIEW || !result)
+		return;
+
+	size = strtol(text, &end, 10);
+	if (size >= 1 && size <= 64 && *end == '\0') {
+		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = size;
+		window_invalidate(w);
+	}
+}
+
+static void window_water_inputsize(rct_window *w)
+{
+	window_text_input_open(w, WIDX_PREVIEW, 5128, 5130, STR_NONE, STR_NONE, 3);
 }
 
 /**

--- a/src/windows/water.c
+++ b/src/windows/water.c
@@ -185,7 +185,9 @@ static void window_water_textinput()
 		return;
 
 	size = strtol(text, &end, 10);
-	if (size >= 1 && size <= 64 && *end == '\0') {
+	if (*end == '\0') {
+		if (size < 1) size = 1;
+		if (size > 64) size = 64;
 		RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) = size;
 		window_invalidate(w);
 	}

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -47,6 +47,8 @@ const rct_xy16 TileDirectionDelta[] = {
 
 rct_xy16 *gMapSelectionTiles = (rct_xy16*)0x009DE596;
 
+bool LandPaintMode;
+
 int _sub_6A876D_save_x;
 int _sub_6A876D_save_y;
 

--- a/src/world/map.h
+++ b/src/world/map.h
@@ -242,6 +242,8 @@ typedef struct {
 
 extern const rct_xy16 TileDirectionDelta[];
 extern rct_xy16 *gMapSelectionTiles;
+// Used in the land tool window to allow dragging and changing land styles
+extern bool LandPaintMode;
 
 void map_init(int size);
 void map_update_tile_pointers();


### PR DESCRIPTION
Beforehand the function was using a "remap" color index instead of an absolute palette index.