### PR TITLE
Fixed editor bottom toolbar right button alignment

### DIFF
--- a/src/windows/editor_bottom_toolbar.c
+++ b/src/windows/editor_bottom_toolbar.c
@@ -392,10 +392,10 @@ void window_editor_bottom_toolbar_invalidate() {
 	window_get_register(w);
 
 	sint16 screenWidth = RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_WIDTH, sint16);
-	window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].left = screenWidth - 198;
-	window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right = screenWidth - 3;
-	window_editor_bottom_toolbar_widgets[WIDX_NEXT_STEP_BUTTON].left = screenWidth - 200;
-	window_editor_bottom_toolbar_widgets[WIDX_NEXT_STEP_BUTTON].right = screenWidth - 1;
+	window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].left = screenWidth - 200;
+	window_editor_bottom_toolbar_widgets[WIDX_NEXT_IMAGE].right = screenWidth - 1;
+	window_editor_bottom_toolbar_widgets[WIDX_NEXT_STEP_BUTTON].left = screenWidth - 198;
+	window_editor_bottom_toolbar_widgets[WIDX_NEXT_STEP_BUTTON].right = screenWidth - 3;
 
 	window_editor_bottom_toolbar_widgets[WIDX_PREVIOUS_STEP_BUTTON].type = WWT_FLATBTN;
 	window_editor_bottom_toolbar_widgets[WIDX_NEXT_STEP_BUTTON].type = WWT_FLATBTN;


### PR DESCRIPTION
The button was improperly sized. I just switched 2 sets of values to fix
that.