### PR TITLE
Fix scenario bugs.

### DIFF
--- a/src/management/research.c
+++ b/src/management/research.c
@@ -278,17 +278,17 @@ void sub_684AC3(){
 	for (; research->entryIndex != -3; research += 2){
 		if (scenario_rand() & 1) continue;
 
-		
 		rct_research_item* edx;
 		rct_research_item* ebp;
-		for (rct_research_item* inner_research = gResearchItems; inner_research->entryIndex != -2; inner_research++){
+		rct_research_item* inner_research = gResearchItems;
+		do{
 			if (research->entryIndex == inner_research->entryIndex){
 				edx = inner_research;
 			}
 			if ((research + 1)->entryIndex == inner_research->entryIndex){
 				ebp = inner_research;
 			}
-		}
+		} while ((inner_research++)->entryIndex != -2);
 		edx->entryIndex = research->entryIndex;
 		ebp->entryIndex = (research + 1)->entryIndex;
 

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -854,8 +854,8 @@ int scenario_prepare_for_save()
 
 	s6Info->objective_type = RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_TYPE, uint8);
 	s6Info->objective_arg_1 = RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_YEAR, uint8);
-	s6Info->objective_arg_2 = RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_CURRENCY, uint8);
-	s6Info->objective_arg_3 = RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_NUM_GUESTS, uint8);
+	s6Info->objective_arg_2 = RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_CURRENCY, sint32);
+	s6Info->objective_arg_3 = RCT2_GLOBAL(RCT2_ADDRESS_OBJECTIVE_NUM_GUESTS, uint16);
 
 	scenario_prepare_rides_for_save();
 


### PR DESCRIPTION
Number of guests and currency were accidentaly being truncated to bytes. This was causing display issues when creating custom scenarios in OpenRCT2.
There was a small bug in research loading that was causing a crash due to exiting of a loop to early. As this was after a call to random this would only occur occasionally.
Fixes #1089 hopefully.