### PR TITLE
Added game speed button and other changes

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3475,3 +3475,12 @@ STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
 STR_5139    :{WHITE}{STRINGID}
 STR_5140    :Disable brakes failure
 STR_5141    :Disable all breakdowns
+STR_5142    :Normal Speed
+STR_5143    :Quick Speed
+STR_5144    :Fast Speed
+STR_5145    :Turbo Speed
+STR_5146    :Ludicrous Speed
+STR_5147    :Show cheats button on toolbar
+STR_5148    :{SMALLFONT}{BLACK}Change the game speed
+STR_5149    :{SMALLFONT}{BLACK}Open the cheats window
+STR_5150    :Enable debugging tools

--- a/src/config.c
+++ b/src/config.c
@@ -154,6 +154,7 @@ config_property_definition _generalDefinitions[] = {
 	{ offsetof(general_configuration, measurement_format),				"measurement_format",			CONFIG_VALUE_TYPE_UINT8,		MEASUREMENT_FORMAT_IMPERIAL,	_measurementFormatEnum	},
 	{ offsetof(general_configuration, play_intro),						"play_intro",					CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, save_plugin_data),				"save_plugin_data",				CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
+	{ offsetof(general_configuration, debugging_tools),					"debugging_tools",				CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, screenshot_format),				"screenshot_format",			CONFIG_VALUE_TYPE_UINT8,		SCREENSHOT_FORMAT_PNG,			_screenShotFormatEnum	},
 	{ offsetof(general_configuration, show_height_as_units),			"show_height_as_units",			CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(general_configuration, temperature_format),				"temperature_format",			CONFIG_VALUE_TYPE_UINT8,		TEMPERATURE_FORMAT_C,			_temperatureFormatEnum	},
@@ -165,6 +166,7 @@ config_property_definition _generalDefinitions[] = {
 config_property_definition _interfaceDefinitions[] = {
 	{ offsetof(interface_configuration, toolbar_show_finances),			"toolbar_show_finances",		CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(interface_configuration, toolbar_show_research),			"toolbar_show_research",		CONFIG_VALUE_TYPE_BOOLEAN,		true,							NULL					},
+	{ offsetof(interface_configuration, toolbar_show_cheats),			"toolbar_show_cheats",			CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(interface_configuration, allow_subtype_switching),		"allow_subtype_switching",		CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 	{ offsetof(interface_configuration, rct1_colour_scheme),			"rct1_colour_scheme",			CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 };

--- a/src/config.h
+++ b/src/config.h
@@ -119,6 +119,7 @@ typedef struct {
 	sint8 landscape_smoothing;
 	sint8 show_height_as_units;
 	sint8 save_plugin_data;
+	uint8 debugging_tools;
 
 	//new
 	uint8 fullscreen_mode;
@@ -134,6 +135,7 @@ typedef struct {
 typedef struct {
 	uint8 toolbar_show_finances;
 	uint8 toolbar_show_research;
+	uint8 toolbar_show_cheats;
 	uint8 allow_subtype_switching;
 	uint8 rct1_colour_scheme;
 } interface_configuration;

--- a/src/game.c
+++ b/src/game.c
@@ -60,12 +60,18 @@ int gGameSpeed = 1;
 
 void game_increase_game_speed()
 {
-	gGameSpeed = min(8, gGameSpeed + 1);
+	gGameSpeed = min(gConfigGeneral.debugging_tools ? 5 : 4, gGameSpeed + 1);
+	if (gGameSpeed == 5)
+		gGameSpeed = 8;
+	window_invalidate_by_class(WC_TOP_TOOLBAR);
 }
 
 void game_reduce_game_speed()
 {
 	gGameSpeed = max(1, gGameSpeed - 1);
+	if (gGameSpeed == 7)
+		gGameSpeed = 4;
+	window_invalidate_by_class(WC_TOP_TOOLBAR);
 }
 
 /**
@@ -256,6 +262,9 @@ void game_update()
 		}
 	}
 
+	news_item_update_current();
+	window_dispatch_update_all();
+
 	RCT2_GLOBAL(0x009A8C28, uint8) = 0;
 
 	RCT2_GLOBAL(RCT2_ADDRESS_INPUT_FLAGS, uint32) &= ~INPUT_FLAG_VIEWPORT_SCROLLING;
@@ -324,11 +333,10 @@ void game_logic_update()
 	vehicle_sounds_update();
 	peep_update_crowd_noise();
 	climate_update_sound();
-	news_item_update_current();
 	editor_open_windows_for_current_step();
 
 	// Update windows
-	window_dispatch_update_all();
+	//window_dispatch_update_all();
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_ERROR_TYPE, uint8) != 0) {
 		rct_string_id title_text = STR_UNABLE_TO_LOAD_FILE;
@@ -865,6 +873,7 @@ void game_load_or_quit_no_save_prompt()
 			RCT2_CALLPROC_EBPSAFE(0x0040705E);
 			RCT2_GLOBAL(RCT2_ADDRESS_INPUT_FLAGS, uint32) &= ~INPUT_FLAG_5;
 		}
+		gGameSpeed = 1;
 		title_load();
 		rct2_endupdate();
 	} else {

--- a/src/localisation/localisation.h
+++ b/src/localisation/localisation.h
@@ -27,6 +27,7 @@
 #include "string_ids.h"
 
 void format_string(char *dest, rct_string_id format, void *args);
+void format_string_part_from_raw(char **dest, const char *src, char **args);
 void generate_string_file();
 void error_string_quit(int error, rct_string_id format);
 int get_string_length(char* buffer);

--- a/src/title.c
+++ b/src/title.c
@@ -278,6 +278,7 @@ void title_update()
 	RCT2_GLOBAL(RCT2_ADDRESS_INPUT_FLAGS, uint32) &= ~0x80;
 
 	window_map_tooltip_update_visibility();
+	window_dispatch_update_all();
 	window_update_all();
 	DrawOpenRCT2(0, RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_HEIGHT, uint16) - 20);
 

--- a/src/windows/cheats.c
+++ b/src/windows/cheats.c
@@ -60,8 +60,6 @@ enum WINDOW_CHEATS_WIDGET_IDX {
 	WIDX_TRAM_GUESTS,
 	WIDX_FREEZE_CLIMATE = 8,
 	WIDX_OPEN_CLOSE_PARK,
-	WIDX_DECREASE_GAME_SPEED,
-	WIDX_INCREASE_GAME_SPEED,
 	WIDX_ZERO_CLEARANCE,
 	WIDX_WEATHER_SUN,
 	WIDX_WEATHER_THUNDER,
@@ -142,8 +140,6 @@ static rct_widget window_cheats_misc_widgets[] = {
 	{ WWT_TAB,				1,	96,			126,	17,		43,		0x2000144E,		2462},						// tab 4
 	{ WWT_CLOSEBOX,			1, XPL(0),	WPL(0),	YPL(0), HPL(0),		2767,			STR_NONE},					// Freeze climate
 	{ WWT_CLOSEBOX,			1, XPL(0),	WPL(0),	YPL(1), HPL(1),		2769,			STR_NONE},					// open / close park
-	{ WWT_CLOSEBOX,			1, XPL(0),	WPL(0),	YPL(2), HPL(2),		2771,			STR_NONE},					// decrease game speed
-	{ WWT_CLOSEBOX,			1, XPL(1),	WPL(1),	YPL(2), HPL(2),		2772,			STR_NONE},					// increase game speed
 	{ WWT_CLOSEBOX,			1, XPL(1),	WPL(1),	YPL(3), HPL(3),		2759,			STR_NONE},					// Zero Clearance
 	{ WWT_CLOSEBOX,			1, XPL(0),	WPL(0),	YPL(4), HPL(4),		2757,			STR_NONE},					// Sun
 	{ WWT_CLOSEBOX,			1, XPL(1),	WPL(1),	YPL(4), HPL(4),		2758,			STR_NONE},					// Thunder
@@ -330,7 +326,7 @@ static void* window_cheats_page_events[] = {
 static uint32 window_cheats_page_enabled_widgets[] = {
 	(1 << WIDX_CLOSE) | (1 << WIDX_TAB_1) | (1 << WIDX_TAB_2) | (1 << WIDX_TAB_3) | (1 << WIDX_TAB_4) | (1 << WIDX_HIGH_MONEY) | (1 << WIDX_PARK_ENTRANCE_FEE),
 	(1 << WIDX_CLOSE) | (1 << WIDX_TAB_1) | (1 << WIDX_TAB_2) | (1 << WIDX_TAB_3) | (1 << WIDX_TAB_4) | (1 << WIDX_HAPPY_GUESTS) | (1 << WIDX_TRAM_GUESTS),
-	(1 << WIDX_CLOSE) | (1 << WIDX_TAB_1) | (1 << WIDX_TAB_2) | (1 << WIDX_TAB_3) | (1 << WIDX_TAB_4) | (1 << WIDX_FREEZE_CLIMATE) | (1 << WIDX_OPEN_CLOSE_PARK) | (1 << WIDX_DECREASE_GAME_SPEED) | (1 << WIDX_INCREASE_GAME_SPEED) | (1 << WIDX_ZERO_CLEARANCE) | (1 << WIDX_WEATHER_SUN) | (1 << WIDX_WEATHER_THUNDER) | (1 << WIDX_CLEAR_GRASS) | (1 << WIDX_MOWED_GRASS) | (1 << WIDX_WATER_PLANTS) | (1 << WIDX_FIX_VANDALISM) | (1 << WIDX_REMOVE_LITTER) | (1 << WIDX_WIN_SCENARIO),
+	(1 << WIDX_CLOSE) | (1 << WIDX_TAB_1) | (1 << WIDX_TAB_2) | (1 << WIDX_TAB_3) | (1 << WIDX_TAB_4) | (1 << WIDX_FREEZE_CLIMATE) | (1 << WIDX_OPEN_CLOSE_PARK) | (1 << WIDX_ZERO_CLEARANCE) | (1 << WIDX_WEATHER_SUN) | (1 << WIDX_WEATHER_THUNDER) | (1 << WIDX_CLEAR_GRASS) | (1 << WIDX_MOWED_GRASS) | (1 << WIDX_WATER_PLANTS) | (1 << WIDX_FIX_VANDALISM) | (1 << WIDX_REMOVE_LITTER) | (1 << WIDX_WIN_SCENARIO),
 	(1 << WIDX_CLOSE) | (1 << WIDX_TAB_1) | (1 << WIDX_TAB_2) | (1 << WIDX_TAB_3) | (1 << WIDX_TAB_4) | (1 << WIDX_RENEW_RIDES) | (1 << WIDX_REMOVE_SIX_FLAGS) | (1 << WIDX_MAKE_DESTRUCTIBLE) | (1 << WIDX_FIX_ALL) | (1 << WIDX_FAST_LIFT_HILL) | (1 << WIDX_DISABLE_BRAKES_FAILURE) | (1 << WIDX_DISABLE_ALL_BREAKDOWNS)
 };
 
@@ -606,12 +602,6 @@ static void window_cheats_misc_mouseup()
 		break;
 	case WIDX_OPEN_CLOSE_PARK:
 		park_set_open(park_is_open() ? 0 : 1);
-		break;
-	case WIDX_DECREASE_GAME_SPEED:
-		game_reduce_game_speed();
-		break;
-	case WIDX_INCREASE_GAME_SPEED:
-		game_increase_game_speed();
 		break;
 	case WIDX_ZERO_CLEARANCE:
 		if (tool_set(w, widgetIndex, 7)) {

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -91,12 +91,14 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_HOTKEY_DROPDOWN,
 	WIDX_TOOLBAR_SHOW_FINANCES,
 	WIDX_TOOLBAR_SHOW_RESEARCH,
+	WIDX_TOOLBAR_SHOW_CHEATS,
 
 	WIDX_REAL_NAME_CHECKBOX,
 	WIDX_SAVE_PLUGIN_DATA_CHECKBOX,
 	WIDX_AUTOSAVE,
 	WIDX_AUTOSAVE_DROPDOWN,
 	WIDX_ALLOW_SUBTYPE_SWITCHING,
+	WIDX_DEBUGGING_TOOLS,
 	WINDOW_OPTIONS_WIDGETS_SIZE // Marks the end of the widget list, leave as last item
 };
 
@@ -149,13 +151,15 @@ static rct_widget window_options_widgets[] = {
 	{ WWT_DROPDOWN_BUTTON,	0,	26,		185,	68,		78,		STR_HOTKEY,		STR_HOTKEY_TIP },
 	{ WWT_CHECKBOX,			2,	10,		299,	82,		93,		5120,			STR_NONE },
 	{ WWT_CHECKBOX,			2,	10,		299,	97,		108,	5121,			STR_NONE },
+	{ WWT_CHECKBOX,			2,	10,		299,	112,	123,	5147,			STR_NONE },
 
 	// Misc
 	{ WWT_CHECKBOX,			2,	10,		299,	53,		64,		STR_REAL_NAME,	STR_REAL_NAME_TIP },
 	{ WWT_CHECKBOX,			2,	10,		299,	68,		79,		STR_SAVE_PLUGIN_DATA, STR_SAVE_PLUGIN_DATA_TIP },
 	{ WWT_DROPDOWN,			0,	155,	299,	83,		94,		STR_NONE,		STR_NONE },
 	{ WWT_DROPDOWN_BUTTON,	0,	288,	298,	84,		93,		876,			STR_NONE },
-	{ WWT_CHECKBOX,			2,	10,		299,	98,		109,	5122,			STR_NONE }, // allow subtype switching
+	{ WWT_CHECKBOX,			2,	10,		299,	98,		109,	5122,			STR_NONE }, // allow subtype 
+	{ WWT_CHECKBOX,			2,	10,		299,	113,	124,	5150,			STR_NONE }, // enabled debugging tools
 	{ WIDGETS_END },
 };
 
@@ -252,6 +256,7 @@ void window_options_open()
 		(1ULL << WIDX_SCREEN_EDGE_SCROLLING) |
 		(1ULL << WIDX_TOOLBAR_SHOW_FINANCES) |
 		(1ULL << WIDX_TOOLBAR_SHOW_RESEARCH) |
+		(1ULL << WIDX_TOOLBAR_SHOW_CHEATS) |
 		(1ULL << WIDX_REAL_NAME_CHECKBOX) |
 		(1ULL << WIDX_CONSTRUCTION_MARKER) |
 		(1ULL << WIDX_CONSTRUCTION_MARKER_DROPDOWN) |
@@ -262,7 +267,8 @@ void window_options_open()
 		(1ULL << WIDX_SAVE_PLUGIN_DATA_CHECKBOX) |
 		(1ULL << WIDX_AUTOSAVE) |
 		(1ULL << WIDX_AUTOSAVE_DROPDOWN) |
-		(1ULL << WIDX_ALLOW_SUBTYPE_SWITCHING);
+		(1ULL << WIDX_ALLOW_SUBTYPE_SWITCHING) |
+		(1ULL << WIDX_DEBUGGING_TOOLS);
 
 	w->page = WINDOW_OPTIONS_PAGE_DISPLAY;
 	window_init_scroll_widgets(w);
@@ -313,11 +319,22 @@ static void window_options_mouseup()
 		window_invalidate(w);
 		window_invalidate_by_class(WC_TOP_TOOLBAR);
 		break;
+	case WIDX_TOOLBAR_SHOW_CHEATS:
+		gConfigInterface.toolbar_show_cheats ^= 1;
+		config_save_default();
+		window_invalidate(w);
+		window_invalidate_by_class(WC_TOP_TOOLBAR);
+		break;
 	case WIDX_ALLOW_SUBTYPE_SWITCHING:
 		gConfigInterface.allow_subtype_switching ^= 1;
 		config_save_default();
 		window_invalidate(w);
 		window_invalidate_by_class(WC_RIDE);
+		break;
+	case WIDX_DEBUGGING_TOOLS:
+		gConfigGeneral.debugging_tools ^= 1;
+		config_save_default();
+		window_invalidate(w);
 		break;
 	case WIDX_REAL_NAME_CHECKBOX:
 		RCT2_GLOBAL(RCT2_ADDRESS_PARK_FLAGS, uint32) ^= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
@@ -750,11 +767,13 @@ static void window_options_invalidate()
 		widget_set_checkbox_value(w, WIDX_SCREEN_EDGE_SCROLLING, gConfigGeneral.edge_scrolling);
 		widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_FINANCES, gConfigInterface.toolbar_show_finances);
 		widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_RESEARCH, gConfigInterface.toolbar_show_research);
+		widget_set_checkbox_value(w, WIDX_TOOLBAR_SHOW_CHEATS, gConfigInterface.toolbar_show_cheats);
 
 		window_options_widgets[WIDX_SCREEN_EDGE_SCROLLING].type = WWT_CHECKBOX;
 		window_options_widgets[WIDX_HOTKEY_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
 		window_options_widgets[WIDX_TOOLBAR_SHOW_FINANCES].type = WWT_CHECKBOX;
 		window_options_widgets[WIDX_TOOLBAR_SHOW_RESEARCH].type = WWT_CHECKBOX;
+		window_options_widgets[WIDX_TOOLBAR_SHOW_CHEATS].type = WWT_CHECKBOX;
 		break;
 	case WINDOW_OPTIONS_PAGE_MISC:
 		widget_set_checkbox_value(w, WIDX_ALLOW_SUBTYPE_SWITCHING, gConfigInterface.allow_subtype_switching);
@@ -781,11 +800,14 @@ static void window_options_invalidate()
 		else
 			window_options_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
 
+		widget_set_checkbox_value(w, WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
+
 		window_options_widgets[WIDX_REAL_NAME_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_widgets[WIDX_AUTOSAVE].type = WWT_DROPDOWN;
 		window_options_widgets[WIDX_AUTOSAVE_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
 		window_options_widgets[WIDX_ALLOW_SUBTYPE_SWITCHING].type = WWT_CHECKBOX;
+		window_options_widgets[WIDX_DEBUGGING_TOOLS].type = WWT_CHECKBOX;
 		break;
 	}
 }

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -54,7 +54,8 @@ enum {
 	WIDX_GUESTS,
 	WIDX_CLEAR_SCENERY,
 
-	//WIDX_FASTFORWARD,
+	WIDX_FASTFORWARD,
+	WIDX_CHEATS,
 	WIDX_FINANCES,
 	WIDX_RESEARCH,
 
@@ -88,8 +89,9 @@ typedef enum {
 // from left to right
 static const int left_aligned_widgets_order[] = {
 	WIDX_PAUSE,
-	//WIDX_FASTFORWARD,
+	WIDX_FASTFORWARD,
 	WIDX_FILE_MENU,
+	WIDX_CHEATS,
 
 	WIDX_SEPARATOR,
 
@@ -141,7 +143,8 @@ static rct_widget window_top_toolbar_widgets[] = {
 	{ WWT_TRNBTN,	3,	0x0230,	0x024D,	0,						27,		0x20000000 | SPR_TOOLBAR_GUESTS,			STR_GUESTS_TIP },					// Guests
 	{ WWT_TRNBTN,	2,	0x0230,	0x024D,	0,						27,		0x20000000 | SPR_TOOLBAR_CLEAR_SCENERY,		STR_CLEAR_SCENERY_TIP },			// Clear scenery
 
-	//{ WWT_TRNBTN,	0,	0x001E,	0x003B,	0,						27,		0x20000000 | 0x15F9,						STR_NONE },							// Fast forward
+	{ WWT_TRNBTN,	0,	0x001E,	0x003B,	0,						27,		0x20000000 | 0x15F9,						5148 },								// Fast forward
+	{ WWT_TRNBTN,	0,	0x001E,	0x003B,	0,						27,		0x20000000 | 0x15F9,						5149 },								// Cheats
 	{ WWT_TRNBTN,	3,	0x001E, 0x003B, 0,						27,		0x20000000 | 0x15F9,						3235 },								// Finances
 	{ WWT_TRNBTN,	3,	0x001E,	0x003B,	0,						27,		0x20000000 | 0x15F9,						2275 },								// Research
 	
@@ -192,6 +195,8 @@ static void* window_top_toolbar_events[] = {
 
 void top_toolbar_init_view_menu(rct_window *window, rct_widget *widget);
 void top_toolbar_view_menu_dropdown(short dropdownIndex);
+void top_toolbar_init_fastforward_menu(rct_window *window, rct_widget *widget);
+void top_toolbar_fastforward_menu_dropdown(short dropdownIndex);
 
 void toggle_footpath_window();
 void toggle_land_window(rct_window *topToolbar, int widgetIndex);
@@ -248,15 +253,6 @@ static void window_top_toolbar_mouseup()
 	case WIDX_PAUSE:
 		game_do_command(0, 1, 0, 0, GAME_COMMAND_TOGGLE_PAUSE, 0, 0);
 		break;
-	// case WIDX_FASTFORWARD:
-	// 	// This is an excellent place to add in debugging statements and
-	// 	// print routines, that will be triggered when you press the
-	// 	// button in the game. Use "git update-index --skip-worktree
-	// 	// src/window_top_toolbar" to avoid committing these changes to
-	// 	// version control.
-	// 	window_cheats_open();
-	// 	break;
-
 	case WIDX_ZOOM_OUT:
 		if ((mainWindow = window_get_main()) != NULL)
 			window_zoom_out(mainWindow);
@@ -307,6 +303,9 @@ static void window_top_toolbar_mouseup()
 		break;
 	case WIDX_RESEARCH:
 		window_research_open();
+		break;
+	case WIDX_CHEATS:
+		window_cheats_open();
 		break;
 	}
 }
@@ -385,6 +384,9 @@ static void window_top_toolbar_mousedown(int widgetIndex, rct_window*w, rct_widg
 		);
 		RCT2_GLOBAL(0x009DEBA2, uint16) = 0;
 		break;
+	case WIDX_FASTFORWARD:
+		top_toolbar_init_fastforward_menu(w, widget);
+		break;
 	}
 }
 
@@ -452,6 +454,9 @@ static void window_top_toolbar_dropdown()
 			break;
 		}
 		break;
+	case WIDX_FASTFORWARD:
+		top_toolbar_fastforward_menu_dropdown(dropdownIndex);
+		break;
 	}
 }
 
@@ -487,6 +492,8 @@ static void window_top_toolbar_invalidate()
 	window_top_toolbar_widgets[WIDX_CLEAR_SCENERY].type = WWT_TRNBTN;
 	window_top_toolbar_widgets[WIDX_FINANCES].type = WWT_TRNBTN;
 	window_top_toolbar_widgets[WIDX_RESEARCH].type = WWT_TRNBTN;
+	window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WWT_TRNBTN;
+	window_top_toolbar_widgets[WIDX_CHEATS].type = WWT_TRNBTN;
 
 	if (RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)) {
 		window_top_toolbar_widgets[WIDX_PAUSE].type = WWT_EMPTY;
@@ -496,6 +503,7 @@ static void window_top_toolbar_invalidate()
 		window_top_toolbar_widgets[WIDX_GUESTS].type = WWT_EMPTY;
 		window_top_toolbar_widgets[WIDX_FINANCES].type = WWT_EMPTY;
 		window_top_toolbar_widgets[WIDX_RESEARCH].type = WWT_EMPTY;
+		window_top_toolbar_widgets[WIDX_CHEATS].type = WWT_EMPTY;
 
 		if (g_editor_step != EDITOR_STEP_LANDSCAPE_EDITOR) {
 			window_top_toolbar_widgets[WIDX_MAP].type = WWT_EMPTY;
@@ -508,6 +516,7 @@ static void window_top_toolbar_invalidate()
 		
 		if (g_editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER) {
 			window_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].type = WWT_EMPTY;
+			window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WWT_EMPTY;
 		}
 
 		if (g_editor_step != EDITOR_STEP_LANDSCAPE_EDITOR && g_editor_step != EDITOR_STEP_ROLLERCOASTER_DESIGNER) {
@@ -522,6 +531,9 @@ static void window_top_toolbar_invalidate()
 
 		if (!gConfigInterface.toolbar_show_research)
 			window_top_toolbar_widgets[WIDX_RESEARCH].type = WWT_EMPTY;
+
+		if (!gConfigInterface.toolbar_show_cheats)
+			window_top_toolbar_widgets[WIDX_CHEATS].type = WWT_EMPTY;
 	}
 
 	enabledWidgets = 0;
@@ -622,10 +634,43 @@ static void window_top_toolbar_paint()
 		gfx_draw_sprite(dpi, imgId, x, y, 0);
 	}
 
+	// Draw fast forward button
+	if (window_top_toolbar_widgets[WIDX_FASTFORWARD].type != WWT_EMPTY) {
+		x = w->x + window_top_toolbar_widgets[WIDX_FASTFORWARD].left + 0;
+		y = w->y + window_top_toolbar_widgets[WIDX_FASTFORWARD].top + 0;
+		if (widget_is_pressed(w, WIDX_FASTFORWARD))
+			y++;
+		//imgId = 5229;//SPR_NEXT;
+		//gfx_draw_sprite(dpi, imgId, x - 1, y - 2, 0);
+		imgId = SPR_NEXT;
+		gfx_draw_sprite(dpi, imgId, x + 4, y, 0);
+
+		char speedStr[] = { FORMAT_MEDIUMFONT, FORMAT_OUTLINE,
+			(gGameSpeed >= 5 ? FORMAT_YELLOW : FORMAT_GREEN),
+			175, (gGameSpeed >= 2 ? 175 : '\0'), (gGameSpeed >= 3 ? 175 : '\0'), (gGameSpeed >= 4 ? 175 : '\0'), '\0'
+		};
+		char* buffer;
+		buffer = RCT2_ADDRESS(RCT2_ADDRESS_COMMON_STRING_FORMAT_BUFFER, char);
+		format_string_part_from_raw(&buffer, &speedStr, NULL);
+		gfx_draw_string(dpi, speedStr, 0, x + 5, y + 14);
+	}
+
+	// Draw cheats button
+	if (window_top_toolbar_widgets[WIDX_CHEATS].type != WWT_EMPTY) {
+		x = w->x + window_top_toolbar_widgets[WIDX_CHEATS].left - 1;
+		y = w->y + window_top_toolbar_widgets[WIDX_CHEATS].top - 1;
+		if (widget_is_pressed(w, WIDX_CHEATS))
+			y++;
+		imgId = SPR_TAB_OBJECTIVE_0;
+		gfx_draw_sprite(dpi, imgId, x, y, 3);
+	}
+
 	// Draw research button
 	if (window_top_toolbar_widgets[WIDX_RESEARCH].type != WWT_EMPTY) {
 		x = w->x + window_top_toolbar_widgets[WIDX_RESEARCH].left - 1;
 		y = w->y + window_top_toolbar_widgets[WIDX_RESEARCH].top;
+		if (widget_is_pressed(w, WIDX_RESEARCH))
+			y++;
 		imgId = SPR_TAB_FINANCES_RESEARCH_0;
 		gfx_draw_sprite(dpi, imgId, x, y, 0);
 	}
@@ -634,6 +679,8 @@ static void window_top_toolbar_paint()
 	if (window_top_toolbar_widgets[WIDX_FINANCES].type != WWT_EMPTY) {
 		x = w->x + window_top_toolbar_widgets[WIDX_FINANCES].left + 3;
 		y = w->y + window_top_toolbar_widgets[WIDX_FINANCES].top + 1;
+		if (widget_is_pressed(w, WIDX_FINANCES))
+			y++;
 		imgId = SPR_FINANCE;
 		gfx_draw_sprite(dpi, imgId, x, y, 0);
 	}
@@ -1783,6 +1830,60 @@ static void window_top_toolbar_tool_drag()
 		if (window_scenery_is_repaint_scenery_tool_on & 1)
 			window_top_toolbar_scenery_tool_down(x, y, w, widgetIndex);
 		break;
+	}
+}
+
+
+void top_toolbar_init_fastforward_menu(rct_window* w, rct_widget* widget) {
+	int num_items = 4;
+	gDropdownItemsFormat[0] = 1156;
+	gDropdownItemsFormat[1] = 1156;
+	gDropdownItemsFormat[2] = 1156;
+	gDropdownItemsFormat[3] = 1156;
+	if (gConfigGeneral.debugging_tools) {
+		gDropdownItemsFormat[4] = 0;
+		gDropdownItemsFormat[5] = 1156;
+		gDropdownItemsArgs[5] = 5146;
+		num_items = 6;
+	}
+
+	gDropdownItemsArgs[0] = 5142;
+	gDropdownItemsArgs[1] = 5143;
+	gDropdownItemsArgs[2] = 5144;
+	gDropdownItemsArgs[3] = 5145;
+	
+
+	window_dropdown_show_text(
+		w->x + widget->left,
+		w->y + widget->top,
+		widget->bottom - widget->top + 1,
+		w->colours[0] | 0x80,
+		0,
+		num_items
+		);
+
+	// Set checkmarks
+	if (gGameSpeed <= 4)
+		gDropdownItemsChecked |= (1 << (gGameSpeed - 1));
+	if (gGameSpeed == 8)
+		gDropdownItemsChecked |= (1 << 5);
+
+	if (gConfigGeneral.debugging_tools)
+		RCT2_GLOBAL(0x9DEBA2, uint16) = (gGameSpeed == 8 ? 0 : gGameSpeed);
+	else
+		RCT2_GLOBAL(0x9DEBA2, uint16) = (gGameSpeed >= 4 ? 0 : gGameSpeed);
+}
+
+void top_toolbar_fastforward_menu_dropdown(short dropdownIndex) {
+	if (dropdownIndex == -1) dropdownIndex = RCT2_GLOBAL(0x9DEBA2, uint16);
+	rct_window* w = window_get_main();
+	if (w) {
+		if (dropdownIndex >= 0 && dropdownIndex <= 5) {
+			gGameSpeed = dropdownIndex + 1;
+			if (gGameSpeed >= 5)
+				gGameSpeed = 8;
+			window_invalidate(w);
+		}
 	}
 }
 


### PR DESCRIPTION
Game speed button with up to 4/5 speeds.
Debugging tools option to enable non-playable changes.
Cheat window is now a setting.
Game speeds 5-7 are removed.
Game speed 8 added with enabling debugging tools.
Windows and news ticker update once per tick instead of based on game
speed.

Preview:
![Game speed](http://i.imgur.com/7eVQ7Jc.png)