### PR TITLE
First decompilation, criticism welcome.

### DIFF
--- a/src/management/finance.c
+++ b/src/management/finance.c
@@ -157,7 +157,8 @@ void finance_reset_history()
 */
 void finance_init() {
 
-	for (short i = 0; i < 56; i++) {
+	// It only initializes the first month
+	for (uint32 i = 0; i < RCT_EXPENDITURE_TYPE_COUNT; i++) {
 		RCT2_ADDRESS(RCT2_ADDRESS_EXPENDITURE_TABLE, money32)[i] = 0;
 	}
 
@@ -297,4 +298,33 @@ void game_command_set_current_loan(int* eax, int* ebx, int* ecx, int* edx, int* 
 	}
 
 	*ebx = 0;
+}
+
+/**
+* Shift the expenditure table history one month to the left
+* If the table is full, acumulate the sum of the oldest month first
+* rct2: 0x0069DEAD
+*/
+
+void finance_shift_expenditure_table() {
+
+	// If EXPENDITURE_TABLE_MONTH_COUNT months have passed then is full, sum the oldest month
+	if (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, uint16) >= EXPENDITURE_TABLE_MONTH_COUNT) {
+		money32 sum = 0;
+		for (uint32 i = EXPENDITURE_TABLE_TOTAL_COUNT - RCT_EXPENDITURE_TYPE_COUNT; i < EXPENDITURE_TABLE_TOTAL_COUNT; i++) {
+			sum += RCT2_ADDRESS(RCT2_ADDRESS_EXPENDITURE_TABLE, money32)[i];
+		}
+		RCT2_GLOBAL(0x013587D0, money32) += sum;
+	}
+	// Shift the table
+	for (uint32 i = EXPENDITURE_TABLE_TOTAL_COUNT - 1; i >= RCT_EXPENDITURE_TYPE_COUNT; i--) {
+		RCT2_ADDRESS(RCT2_ADDRESS_EXPENDITURE_TABLE, money32)[i] =
+			RCT2_ADDRESS(RCT2_ADDRESS_EXPENDITURE_TABLE, money32)[i - RCT_EXPENDITURE_TYPE_COUNT];
+	}
+	// Zero the beggining of the table, which is the new month
+	for (uint32 i = 0; i < RCT_EXPENDITURE_TYPE_COUNT; i++) {
+		RCT2_ADDRESS(RCT2_ADDRESS_EXPENDITURE_TABLE, money32)[i] = 0;
+	}
+	// Invalidate the expenditure table window
+	window_invalidate_by_number(0x1C, 0);
 }

--- a/src/management/finance.h
+++ b/src/management/finance.h
@@ -39,8 +39,12 @@ enum {
 	RCT_EXPENDITURE_TYPE_WAGES,
 	RCT_EXPENDITURE_TYPE_MARKETING,
 	RCT_EXPENDITURE_TYPE_RESEARCH,
-	RCT_EXPENDITURE_TYPE_INTEREST
+	RCT_EXPENDITURE_TYPE_INTEREST,
+	RCT_EXPENDITURE_TYPE_COUNT
 };
+
+#define EXPENDITURE_TABLE_MONTH_COUNT 16
+#define EXPENDITURE_TABLE_TOTAL_COUNT (EXPENDITURE_TABLE_MONTH_COUNT * RCT_EXPENDITURE_TYPE_COUNT)
 
 extern const money32 research_cost_table[4];
 
@@ -52,6 +56,7 @@ void finance_pay_ride_upkeep();
 void finance_reset_history();
 void finance_init();
 void finance_update_daily_profit();
+void finance_shift_expenditure_table();
 void sub_69E869();
 
 void finance_set_loan(money32 loan);

--- a/src/scenario.c
+++ b/src/scenario.c
@@ -725,7 +725,7 @@ void scenario_update()
 		// month ends actions
 		RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_MONTH_YEAR, sint16)++;
 		RCT2_GLOBAL(RCT2_ADDRESS_BTM_TOOLBAR_DIRTY_FLAGS, uint32) |= BTM_TB_DIRTY_FLAG_DATE;
-		RCT2_CALLPROC_EBPSAFE(0x0069DEAD);
+		finance_shift_expenditure_table();
 		scenario_objectives_check();
 		scenario_entrance_fee_too_high_check();
 		award_update_all();


### PR DESCRIPTION
Decompiled 0x0069DEAD, it's now called finance_shift_expenditure_table.
Added some defines for the expenditure table size, the expenditure table saves the history up to 16 months but only shows 5 in-game.
Fixed an inconsistency with the assembler code in finance_init(), it only initializes the first month, not four.