### PR TITLE
Make 'Default audio device' translatable

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3484,3 +3484,8 @@ STR_5147    :Show cheats button on toolbar
 STR_5148    :{SMALLFONT}{BLACK}Change the game speed
 STR_5149    :{SMALLFONT}{BLACK}Open the cheats window
 STR_5150    :Enable debugging tools
+<<<<<<< HEAD
+=======
+STR_5151    :Default sound device
+STR_5152    :(UNKNOWN)
+>>>>>>> Make 'Default audio device' translatable.

--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3484,8 +3484,5 @@ STR_5147    :Show cheats button on toolbar
 STR_5148    :{SMALLFONT}{BLACK}Change the game speed
 STR_5149    :{SMALLFONT}{BLACK}Open the cheats window
 STR_5150    :Enable debugging tools
-<<<<<<< HEAD
-=======
 STR_5151    :Default sound device
 STR_5152    :(UNKNOWN)
->>>>>>> Make 'Default audio device' translatable.

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -23,6 +23,7 @@
 #include "../config.h"
 #include "../interface/viewport.h"
 #include "../interface/window.h"
+#include "../localisation/language.h"
 #include "../platform/platform.h"
 #include "../world/map.h"
 #include "../world/sprite.h"
@@ -68,11 +69,11 @@ void audio_get_devices()
 		gAudioDeviceCount++;
 		gAudioDevices = malloc(gAudioDeviceCount * sizeof(audio_device));
 
-		strcpy(gAudioDevices[0].name, "Default sound device");
+		strcpy(gAudioDevices[0].name, language_get_string(5151));
 		for (i = 1; i < gAudioDeviceCount; i++) {
 			const char *utf8_name = SDL_GetAudioDeviceName(i - 1, SDL_FALSE);
 			if (utf8_name == NULL)
-				utf8_name = "(UNKNOWN)";
+				utf8_name = language_get_string(5152);
 
 			strcpy(gAudioDevices[i].name, utf8_name);
 		}


### PR DESCRIPTION
Work in progress, don't merge yet.

The string for 'Default audio device' is untranslatable. This PR should solve it.
However, I noticed string issues, with Default audio device showing up as (undefined string) until invalidation is forced, and other invalidation issues as well:

![scr73](https://cloud.githubusercontent.com/assets/1478678/7723122/7d9b4dc8-fee6-11e4-84f2-58b0920d003b.png)
