### PR TITLE
Fix #1103 and #483

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -869,6 +869,7 @@ void game_load_or_quit_no_save_prompt()
 			load_game();
 	} else if (RCT2_GLOBAL(RCT2_ADDRESS_SAVE_PROMPT_MODE, uint16) == 1) {
 		game_do_command(0, 1, 0, 1, GAME_COMMAND_LOAD_OR_QUIT, 0, 0);
+		tool_cancel();
 		if (RCT2_GLOBAL(RCT2_ADDRESS_INPUT_FLAGS, uint32) & INPUT_FLAG_5) {
 			RCT2_CALLPROC_EBPSAFE(0x0040705E);
 			RCT2_GLOBAL(RCT2_ADDRESS_INPUT_FLAGS, uint32) &= ~INPUT_FLAG_5;

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -796,7 +796,7 @@ static void* window_ride_music_events[] = {
 
 // 0x0098DE14
 static void* window_ride_measurements_events[] = {
-	window_ride_emptysub,
+	window_ride_measurements_close,
 	window_ride_measurements_mouseup,
 	window_ride_measurements_resize,
 	window_ride_measurements_mousedown,


### PR DESCRIPTION
Measurement close is now correctly called when the ride measurement window is closed.
When quiting a scenario tool_cancel is called to also reset the scnery selection mode