### PR TITLE
Testing Improvements

### DIFF
--- a/data/language/english_uk.txt
+++ b/data/language/english_uk.txt
@@ -3488,3 +3488,5 @@ STR_5151    :,
 STR_5152    :.
 STR_5153    :RCT1 colour scheme
 STR_5154    :Hardware display
+STR_5155    :Allow testing of unfinished tracks
+STR_5156    :{SMALLFONT}{BLACK}Allows testing of most ride types even when the track is unfinished, does not apply to block sectioned modes

--- a/src/config.c
+++ b/src/config.c
@@ -162,6 +162,8 @@ config_property_definition _generalDefinitions[] = {
 	{ offsetof(general_configuration, window_snap_proximity),			"window_snap_proximity",		CONFIG_VALUE_TYPE_UINT8,		5,								NULL					},
 	{ offsetof(general_configuration, window_width),					"window_width",					CONFIG_VALUE_TYPE_SINT32,		-1,								NULL					},
 	{ offsetof(general_configuration, hardware_display),				"hardware_display",				CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
+	{ offsetof(general_configuration, test_unfinished_tracks),			"test_unfinished_tracks",		CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
+	{ offsetof(general_configuration, no_test_crashes),					"no_test_crashes",				CONFIG_VALUE_TYPE_BOOLEAN,		false,							NULL					},
 };
 
 config_property_definition _interfaceDefinitions[] = {

--- a/src/config.h
+++ b/src/config.h
@@ -131,6 +131,8 @@ typedef struct {
 	uint8 window_snap_proximity;
 	uint8 autosave_frequency;
 	uint8 hardware_display;
+	uint8 test_unfinished_tracks;
+	uint8 no_test_crashes;
 } general_configuration;
 
 typedef struct {

--- a/src/interface/console.c
+++ b/src/interface/console.c
@@ -489,6 +489,12 @@ static int cc_get(const char **argv, int argc)
 		else if (strcmp(argv[0], "console_small_font") == 0) {
 			console_printf("console_small_font %d", gConfigInterface.console_small_font);
 		}
+		else if (strcmp(argv[0], "test_unfinished_tracks") == 0) {
+			console_printf("test_unfinished_tracks %d", gConfigGeneral.test_unfinished_tracks);
+		}
+		else if (strcmp(argv[0], "no_test_crashes") == 0) {
+			console_printf("no_test_crashes %d", gConfigGeneral.no_test_crashes);
+		}
 		else {
 			console_writeline_warning("Invalid variable.");
 		}
@@ -607,6 +613,16 @@ static int cc_set(const char **argv, int argc)
 			config_save_default();
 			console_execute_silent("get console_small_font");
 		}
+		else if (strcmp(argv[0], "test_unfinished_tracks") == 0 && int_valid) {
+			gConfigGeneral.test_unfinished_tracks = (int_val != 0);
+			config_save_default();
+			console_execute_silent("get test_unfinished_tracks");
+		}
+		else if (strcmp(argv[0], "no_test_crashes") == 0 && int_valid) {
+			gConfigGeneral.no_test_crashes = (int_val != 0);
+			config_save_default();
+			console_execute_silent("get no_test_crashes");
+		}
 		else {
 			console_writeline_error("Invalid variable or value.");
 		}
@@ -648,7 +664,9 @@ char* console_variable_table[] = {
 	"park_open",
 	"climate",
 	"game_speed",
-	"console_small_font"
+	"console_small_font",
+	"test_unfinished_tracks",
+	"no_test_crashes"
 };
 
 console_command console_command_table[] = {

--- a/src/ride/ride.h
+++ b/src/ride/ride.h
@@ -362,7 +362,10 @@ enum {
 	RIDE_LIFECYCLE_16 = 1 << 16,
 	RIDE_LIFECYCLE_CABLE_LIFT = 1 << 17,
 	RIDE_LIFECYCLE_18 = 1 << 18,
-	RIDE_LIFECYCLE_SIX_FLAGS = 1 << 19
+	RIDE_LIFECYCLE_SIX_FLAGS = 1 << 19,
+
+	// Used to bring up the "real" ride window after a crash. Can be removed once vehicle_update is decompiled
+	RIDE_LIFECYCLE_CRASHED_WINDOW_OPENED = 1 << 20
 };
 
 enum {

--- a/src/windows/options.c
+++ b/src/windows/options.c
@@ -101,11 +101,12 @@ enum WINDOW_OPTIONS_WIDGET_IDX {
 	WIDX_AUTOSAVE_DROPDOWN,
 	WIDX_ALLOW_SUBTYPE_SWITCHING,
 	WIDX_DEBUGGING_TOOLS,
+	WIDX_TEST_UNFINISHED_TRACKS,
 	WINDOW_OPTIONS_WIDGETS_SIZE // Marks the end of the widget list, leave as last item
 };
 
 #define WW 310
-#define WH 153
+#define WH 183
 
 static rct_widget window_options_widgets[] = {
 	{ WWT_FRAME,			0,	0,		WW - 1,	0,		WH - 1,	STR_NONE,		STR_NONE },
@@ -164,6 +165,7 @@ static rct_widget window_options_widgets[] = {
 	{ WWT_DROPDOWN_BUTTON,	0,	288,	298,	84,		93,		876,			STR_NONE },
 	{ WWT_CHECKBOX,			2,	10,		299,	98,		109,	5122,			STR_NONE }, // allow subtype 
 	{ WWT_CHECKBOX,			2,	10,		299,	113,	124,	5150,			STR_NONE }, // enabled debugging tools
+	{ WWT_CHECKBOX,			2,	10,		299,	128,	139,	5155,			5156 }, // test unfinished tracks
 	{ WIDGETS_END },
 };
 
@@ -274,6 +276,7 @@ void window_options_open()
 		(1ULL << WIDX_AUTOSAVE_DROPDOWN) |
 		(1ULL << WIDX_ALLOW_SUBTYPE_SWITCHING) |
 		(1ULL << WIDX_DEBUGGING_TOOLS) |
+		(1ULL << WIDX_TEST_UNFINISHED_TRACKS) |
 		(1ULL << WIDX_RCT1_COLOUR_SCHEME);
 
 	w->page = WINDOW_OPTIONS_PAGE_DISPLAY;
@@ -344,6 +347,11 @@ static void window_options_mouseup()
 		break;
 	case WIDX_DEBUGGING_TOOLS:
 		gConfigGeneral.debugging_tools ^= 1;
+		config_save_default();
+		window_invalidate(w);
+		break;
+	case WIDX_TEST_UNFINISHED_TRACKS:
+		gConfigGeneral.test_unfinished_tracks ^= 1;
 		config_save_default();
 		window_invalidate(w);
 		break;
@@ -827,6 +835,7 @@ static void window_options_invalidate()
 			window_options_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
 
 		widget_set_checkbox_value(w, WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
+		widget_set_checkbox_value(w, WIDX_TEST_UNFINISHED_TRACKS, gConfigGeneral.test_unfinished_tracks);
 
 		window_options_widgets[WIDX_REAL_NAME_CHECKBOX].type = WWT_CHECKBOX;
 		window_options_widgets[WIDX_SAVE_PLUGIN_DATA_CHECKBOX].type = WWT_CHECKBOX;
@@ -834,6 +843,7 @@ static void window_options_invalidate()
 		window_options_widgets[WIDX_AUTOSAVE_DROPDOWN].type = WWT_DROPDOWN_BUTTON;
 		window_options_widgets[WIDX_ALLOW_SUBTYPE_SWITCHING].type = WWT_CHECKBOX;
 		window_options_widgets[WIDX_DEBUGGING_TOOLS].type = WWT_CHECKBOX;
+		window_options_widgets[WIDX_TEST_UNFINISHED_TRACKS].type = WWT_CHECKBOX;
 		break;
 	}
 }


### PR DESCRIPTION
Added test_unfinished_tracks and no_test_crashes
Both are enablable through the console and test_unfinished_tracks is also an option.
Increased options window height.
Made it so "out" ride window is opened after a crash instead of RCT2's ride window.
ride_is_valid_for_open has a counterpart: ride_is_valid_for_test