### PR TITLE
Fixed "whizzed" images #1070

### DIFF
--- a/src/ride/ride.c
+++ b/src/ride/ride.c
@@ -150,7 +150,7 @@ rct_ride_type *ride_get_entry(rct_ride *ride)
 */
 void reset_type_to_ride_entry_index_map(){
 	uint8* typeToRideEntryIndexMap = RCT2_ADDRESS(0x009E32F8, uint8);
-	memset(typeToRideEntryIndexMap, 0xFF, 90);
+	memset(typeToRideEntryIndexMap, 0xFF, 91);
 }
 
 uint8 *get_ride_entry_indices_for_ride_type(uint8 rideType)


### PR DESCRIPTION
In reset_type_to_ride_entry_index_map() we were simply reseting everything up-to but excluding LIM launched (the last ride type)