### PR TITLE
OpenRCT2 no longer crashes after station abuse.

### DIFF
--- a/src/ride/station.c
+++ b/src/ride/station.c
@@ -291,6 +291,10 @@ static void ride_invalidate_station_start(rct_ride *ride, int stationIndex, int 
 	y = (ride->station_starts[stationIndex] >> 8) * 32;
 	mapElement = ride_get_station_start_track_element(ride, stationIndex);
 
+	// If no station track found return
+	if (mapElement == NULL)
+		return;
+
 	mapElement->properties.track.sequence &= 0x7F;
 	if (dl != 0)
 		mapElement->properties.track.sequence |= 0x80;


### PR DESCRIPTION
Certain 8cars functions would move station track pieces that would cause the game to crash as they would not be at the correct location. OpenRCT2 will just skip trying to update the tiles of station track that has been modified this way

Fixes #1157 and any other custom map with station abuse.