### PR TITLE
Toolbar Update Functions

### DIFF
--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1665,9 +1665,9 @@ void screen_pos_to_map_pos(sint16 *x, sint16 *y, int *direction)
 			}
 		} else {
 			if (mod_y < 16) {
-				my_direction = 0;
-			} else {
 				my_direction = 1;
+			} else {
+				my_direction = 0;
 			}
 		}
 	}

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1955,7 +1955,7 @@ void sub_68862C()
  * mapElement: edx
  * viewport: edi
  */
-void get_map_coordinates_from_pos(int screenX, int screenY, int flags, int *x, int *y, int *interactionType, rct_map_element **mapElement, rct_viewport **viewport)
+void get_map_coordinates_from_pos(int screenX, int screenY, int flags, sint16 *x, sint16 *y, int *interactionType, rct_map_element **mapElement, rct_viewport **viewport)
 {
 	RCT2_GLOBAL(0x9AC154, uint16_t) = flags & 0xFFFF;
 	RCT2_GLOBAL(0x9AC148, uint8_t) = 0;
@@ -1994,7 +1994,7 @@ void get_map_coordinates_from_pos(int screenX, int screenY, int flags, int *x, i
 		if (viewport != NULL) *viewport = myviewport;
 	}
 	if (interactionType != NULL) *interactionType = RCT2_GLOBAL(0x9AC148, uint8_t);
-	if (x != NULL) *x = (int)RCT2_GLOBAL(0x9AC14C, int16_t);
-	if (y != NULL) *y = (int)RCT2_GLOBAL(0x9AC14E, int16_t);
+	if (x != NULL) *x = RCT2_GLOBAL(0x9AC14C, int16_t);
+	if (y != NULL) *y = RCT2_GLOBAL(0x9AC14E, int16_t);
 	if (mapElement != NULL) *mapElement = RCT2_GLOBAL(0x9AC150, rct_map_element*);
 }

--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1609,7 +1609,8 @@ void viewport_paint(rct_viewport* viewport, rct_drawpixelinfo* dpi, int left, in
  *		viewport: edi
  */
 void sub_688972(int screenX, int screenY, sint16 *x, sint16 *y, rct_viewport **viewport) {
-	int my_x, my_y, z, interactionType;
+	sint16 my_x, my_y;
+	int z, interactionType;
 	rct_viewport *myViewport;
 	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_TERRAIN, &my_x, &my_y, &interactionType, NULL, &myViewport);
 	if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE) {

--- a/src/interface/viewport.h
+++ b/src/interface/viewport.h
@@ -113,7 +113,7 @@ void show_construction_rights();
 void hide_construction_rights();
 void viewport_set_visibility(uint8 mode);
 
-void get_map_coordinates_from_pos(int screenX, int screenY, int flags, int *x, int *y, int *interactionType, rct_map_element **mapElement, rct_viewport **viewport);
+void get_map_coordinates_from_pos(int screenX, int screenY, int flags, sint16 *x, sint16 *y, int *interactionType, rct_map_element **mapElement, rct_viewport **viewport);
 
 int viewport_interaction_get_item_left(int x, int y, viewport_interaction_info *info);
 int viewport_interaction_left_over(int x, int y);

--- a/src/interface/viewport_interaction.c
+++ b/src/interface/viewport_interaction.c
@@ -59,7 +59,10 @@ int viewport_interaction_get_item_left(int x, int y, viewport_interaction_info *
 	if ((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_DESIGNER) && s6Info->var_000 != 6)
 		return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
 
-	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_SPRITE & VIEWPORT_INTERACTION_MASK_RIDE & VIEWPORT_INTERACTION_MASK_PARK, &info->x, &info->y, &info->type, &info->mapElement, NULL);
+	rct_xy16 mapCoord = { 0 };
+	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_SPRITE & VIEWPORT_INTERACTION_MASK_RIDE & VIEWPORT_INTERACTION_MASK_PARK, &mapCoord.x, &mapCoord.y, &info->type, &info->mapElement, NULL);
+	info->x = mapCoord.x;
+	info->y = mapCoord.y;
 	mapElement = info->mapElement;
 	sprite = (rct_sprite*)mapElement;
 
@@ -179,7 +182,10 @@ int viewport_interaction_get_item_right(int x, int y, viewport_interaction_info 
 	if ((RCT2_GLOBAL(RCT2_ADDRESS_SCREEN_FLAGS, uint8) & SCREEN_FLAGS_TRACK_DESIGNER) && s6Info->var_000 != 6)
 		return info->type = VIEWPORT_INTERACTION_ITEM_NONE;
 
-	get_map_coordinates_from_pos(x, y, ~(VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER), &info->x, &info->y, &info->type, &info->mapElement, NULL);
+	rct_xy16 mapCoord = { 0 };
+	get_map_coordinates_from_pos(x, y, ~(VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER), &mapCoord.x, &mapCoord.y, &info->type, &info->mapElement, NULL);
+	info->x = mapCoord.x;
+	info->y = mapCoord.y;
 	mapElement = info->mapElement;
 	sprite = (rct_sprite*)mapElement;
 
@@ -566,7 +572,8 @@ static rct_peep *viewport_interaction_get_closest_peep(int x, int y, int maxDist
  */
 void sub_68A15E(int screenX, int screenY, short *x, short *y, int *direction, rct_map_element **mapElement)
 {
-	int my_x, my_y, z, interactionType;
+	sint16 my_x, my_y;
+	int z, interactionType;
 	rct_map_element *myMapElement;
 	rct_viewport *viewport;
 	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_TERRAIN & VIEWPORT_INTERACTION_MASK_WATER, &my_x, &my_y, &interactionType, &myMapElement, &viewport);

--- a/src/windows/footpath.c
+++ b/src/windows/footpath.c
@@ -673,7 +673,10 @@ static void window_footpath_set_provisional_path_at_point(int x, int y)
 	map_invalidate_selection_rect();
 	RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~(1 << 2);
 
-	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN, &x, &y, &interactionType, &mapElement, NULL);
+	rct_xy16 mapCoord = { 0 };
+	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN, &mapCoord.x, &mapCoord.y, &interactionType, &mapElement, NULL);
+	x = mapCoord.x;
+	y = mapCoord.y;
 
 	if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE) {
 		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~(1 << 0);
@@ -760,7 +763,11 @@ static void window_footpath_place_path_at_point(int x, int y)
 
 	footpath_provisional_update();
 
-	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN, &x, &y, &interactionType, &mapElement, NULL);
+	rct_xy16 mapCoord = { 0 };
+	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN, &mapCoord.x, &mapCoord.y, &interactionType, &mapElement, NULL);
+	x = mapCoord.x;
+	y = mapCoord.y;
+
 	if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE)
 		return;
 

--- a/src/windows/park.c
+++ b/src/windows/park.c
@@ -814,6 +814,7 @@ static void window_park_entrance_toolupdate()
 
 	switch (widgetIndex){
 	case WIDX_BUY_LAND_RIGHTS:
+		// Create a new version for this instance as scenery_clear is silly for this
 		RCT2_CALLPROC_X(0x0068E213, x, y, 0, widgetIndex, (int)w, 0, 0);
 		RCT2_GLOBAL(0x00F1AD62, uint32) = game_do_command(
 			RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, uint16),

--- a/src/windows/ride.c
+++ b/src/windows/ride.c
@@ -3565,7 +3565,10 @@ static void window_ride_set_track_colour_scheme(rct_window *w, int x, int y)
 
 	int interactionType;
 
-	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_RIDE, &x, &y, &interactionType, &mapElement, NULL);
+	rct_xy16 mapCoord = { 0 };
+	get_map_coordinates_from_pos(x, y, VIEWPORT_INTERACTION_MASK_RIDE, &mapCoord.x, &mapCoord.y, &interactionType, &mapElement, NULL);
+	x = mapCoord.x;
+	y = mapCoord.y;
 	// Get map coordinates from point
 	/*int eax, ebx, ecx, edx, esi, edi, ebp;
 	eax = x;

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -209,6 +209,9 @@ void toggle_land_window(rct_window *topToolbar, int widgetIndex);
 void toggle_clear_scenery_window(rct_window *topToolbar, int widgetIndex);
 void toggle_water_window(rct_window *topToolbar, int widgetIndex);
 
+money32 selection_lower_land(uint8 flags);
+money32 selection_raise_land(uint8 flags);
+
 static bool _menuDropdownIncludesTwitch;
 
 /**
@@ -1620,6 +1623,176 @@ void top_toolbar_tool_update_scenery_clear(sint16 x, sint16 y){
 }
 
 /**
+*
+*  rct2: 0x00664280
+*/
+void top_toolbar_tool_update_land(sint16 x, sint16 y){
+	map_invalidate_selection_rect();
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_CURRENT_TOOL, uint8) == 3){
+		if (!(RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & (1 << 0)))
+			return;
+
+		money32 lower_cost = selection_lower_land(0);
+		money32 raise_cost = selection_raise_land(0);
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) != raise_cost || 
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) != lower_cost){
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) = raise_cost;
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) = lower_cost;
+			window_invalidate_by_class(WC_LAND);
+		}
+		return;
+	}
+
+	sint16 tool_size = RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16);
+	rct_xy16 mapTile = { .x = x, .y = y };
+
+	RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~(1 << 0);
+	if (tool_size == 1){
+		int direction;
+		screen_pos_to_map_pos(&mapTile.x, &mapTile.y, &direction);
+
+		if (mapTile.x == (sint16)0x8000){
+			money32 lower_cost = MONEY32_UNDEFINED;
+			money32 raise_cost = MONEY32_UNDEFINED;
+
+			if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) != raise_cost ||
+				RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) != lower_cost){
+				RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) = raise_cost;
+				RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) = lower_cost;
+				window_invalidate_by_class(WC_LAND);
+			}
+			return;
+		}
+
+		uint8 state_changed = 0;
+
+		if (!(RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & (1 << 0))){
+			RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 0);
+			state_changed++;
+		}
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) != direction){
+			RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = direction;
+			state_changed++;
+		}
+
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) != mapTile.x){
+			RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) = mapTile.x;
+			state_changed++;
+		}
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) != mapTile.y){
+			RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) = mapTile.y;
+			state_changed++;
+		}
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) != mapTile.x){
+			RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) = mapTile.x;
+			state_changed++;
+		}
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) != mapTile.y){
+			RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) = mapTile.y;
+			state_changed++;
+		}
+
+		map_invalidate_selection_rect();
+		if (!state_changed)
+			return;
+
+		money32 lower_cost = selection_lower_land(0);
+		money32 raise_cost = selection_raise_land(0);
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) != raise_cost ||
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) != lower_cost){
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) = raise_cost;
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) = lower_cost;
+			window_invalidate_by_class(WC_LAND);
+		}
+		return;
+	}
+
+	sub_688972(x, y, &mapTile.x, &mapTile.y, NULL);
+
+	if (mapTile.x == (sint16)0x8000){
+		money32 lower_cost = MONEY32_UNDEFINED;
+		money32 raise_cost = MONEY32_UNDEFINED;
+
+		if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) != raise_cost ||
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) != lower_cost){
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) = raise_cost;
+			RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) = lower_cost;
+			window_invalidate_by_class(WC_LAND);
+		}
+		return;
+	}
+
+	uint8 state_changed = 0;
+
+	if (!(RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & (1 << 0))){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 0);
+		state_changed++;
+	}
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) != 4){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = 4;
+		state_changed++;
+	}
+
+	
+	if (tool_size == 0)
+		tool_size = 1;
+
+	sint16 tool_length = (tool_size - 1) * 32;
+
+	// Move to tool bottom left
+	mapTile.x -= (tool_size - 1) * 16;
+	mapTile.y -= (tool_size - 1) * 16;
+	mapTile.x &= 0xFFE0;
+	mapTile.y &= 0xFFE0;
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) != mapTile.x){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) = mapTile.x;
+		state_changed++;
+	}
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) != mapTile.y){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) = mapTile.y;
+		state_changed++;
+	}
+
+	mapTile.x += tool_length;
+	mapTile.y += tool_length;
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) != mapTile.x){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) = mapTile.x;
+		state_changed++;
+	}
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) != mapTile.y){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) = mapTile.y;
+		state_changed++;
+	}
+
+	map_invalidate_selection_rect();
+	if (!state_changed)
+		return;
+
+	money32 lower_cost = selection_lower_land(0);
+	money32 raise_cost = selection_raise_land(0);
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) != raise_cost ||
+		RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) != lower_cost){
+		RCT2_GLOBAL(RCT2_ADDRESS_LAND_RAISE_COST, money32) = raise_cost;
+		RCT2_GLOBAL(RCT2_ADDRESS_LAND_LOWER_COST, money32) = lower_cost;
+		window_invalidate_by_class(WC_LAND);
+	}
+}
+
+/**
  *
  *  rct2: 0x0066CB25
  */
@@ -1640,7 +1813,7 @@ static void window_top_toolbar_tool_update()
 			// Create a new version for this instance as scenery_clear is silly for this
 			RCT2_CALLPROC_X(0x0068E213, x, y, 0, widgetIndex, (int)w, 0, 0);
 		else
-			RCT2_CALLPROC_X(0x00664280, x, y, 0, widgetIndex, (int)w, 0, 0);
+			top_toolbar_tool_update_land(x, y);
 		break;
 	case WIDX_WATER:
 		RCT2_CALLPROC_X(0x006E6BDC, x, y, 0, widgetIndex, (int)w, 0, 0);
@@ -1709,7 +1882,7 @@ static void window_top_toolbar_tool_down(){
 *  
 *  rct2: 0x006644DD
 */
-void selection_raise_land(uint8 flags){
+money32 selection_raise_land(uint8 flags){
 	int center_x = (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, uint16) +
 		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, uint16)
 		) / 2;
@@ -1730,12 +1903,12 @@ void selection_raise_land(uint8 flags){
 	if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) == 0) {
 		int di = 1;
 
-		game_do_command(center_x, flags, center_y, dx, GAME_COMMAND_EDIT_LAND_SMOOTH, di, bp);
+		return game_do_command(center_x, flags, center_y, dx, GAME_COMMAND_EDIT_LAND_SMOOTH, di, bp);
 	}
 	else {
 		int di = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16);
 
-		game_do_command(center_x, flags, center_y, dx, GAME_COMMAND_RAISE_LAND, di, bp);
+		return game_do_command(center_x, flags, center_y, dx, GAME_COMMAND_RAISE_LAND, di, bp);
 	}
 }
 
@@ -1743,7 +1916,7 @@ void selection_raise_land(uint8 flags){
 *
 *  rct2: 0x006645B3
 */
-void selection_lower_land(uint8 flags){
+money32 selection_lower_land(uint8 flags){
 	int center_x = (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, uint16) + 
 		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, uint16)
 		) / 2;
@@ -1764,11 +1937,11 @@ void selection_lower_land(uint8 flags){
 	if (RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16) == 0) {
 		int di = 0xFFFF;
 
-		game_do_command(center_x, flags, center_y, dx, GAME_COMMAND_EDIT_LAND_SMOOTH, di, bp);
+		return game_do_command(center_x, flags, center_y, dx, GAME_COMMAND_EDIT_LAND_SMOOTH, di, bp);
 	} else {
 		int di = RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16);
 
-		game_do_command(center_x, flags, center_y, dx, GAME_COMMAND_LOWER_LAND, di, bp);
+		return game_do_command(center_x, flags, center_y, dx, GAME_COMMAND_LOWER_LAND, di, bp);
 	}
 }
 

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -1918,6 +1918,15 @@ void top_toolbar_tool_update_water(sint16 x, sint16 y){
 	}
 }
 
+money32 sub_6E24F6(rct_xy16 map_tile, uint32 parameter_1, uint32 parameter_2, uint32 parameter_3, uint16 selected_tab){
+
+	int eax = map_tile.x, ebx = parameter_1, ecx = map_tile.y, edx = parameter_2, esi = 0, ebp = selected_tab, edi = parameter_3;
+
+	RCT2_CALLFUNC_X(0x006E24F6, &eax, &ebx, &ecx, &edx, &esi, &edi, &ebp);
+
+	return (money32)ebx;
+}
+
 /**
 *
 *  rct2: 0x006E287B
@@ -1950,16 +1959,171 @@ void top_toolbar_tool_update_scenery(sint16 x, sint16 y){
 		return;
 	}
 	
+	rct_scenery_entry* scenery;
+	uint8 bl;
+	money32 cost;
+
 	switch (scenery_type){
 	case 0:
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 0);
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) = mapTile.x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) = mapTile.y;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) = mapTile.x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) = mapTile.y;
+
+		scenery = g_smallSceneryEntries[selected_scenery];
+
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = 4;
+		if (!(scenery->small_scenery.flags & SMALL_SCENERY_FLAG_FULL_TILE)){
+			RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = ((parameter2 & 0xFF) ^ 2) + 6;
+		}
+
+		map_invalidate_selection_rect();
+
+		// If no change in ghost placement
+		if ((RCT2_GLOBAL(0x00F64F0D, uint8) & (1 << 0)) &&
+			mapTile.x == RCT2_GLOBAL(0x00F64EC4, sint16) &&
+			mapTile.y == RCT2_GLOBAL(0x00F64EC6, sint16) &&
+			(parameter2 & 0xFF) == RCT2_GLOBAL(0x00F64F0E, uint8)&&
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) == RCT2_GLOBAL(0x00F64F0A, sint16) &&
+			RCT2_GLOBAL(0x00F64EDA, uint16) == selected_tab){
+			return;		
+		}
+
+		scenery_remove_ghost_tool_placement();
+
+		RCT2_GLOBAL(0x00F64F0E, uint8) = (parameter2 & 0xFF);
+		RCT2_GLOBAL(0x00F64F0A, sint16) = RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16);
+
+		bl = 1;
+		if (RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) != 0 &&
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_TOOL_SHIFT_PRESSED, uint8) != 0){
+			bl = 20;
+		}
+
+		for (; bl != 0; bl--){
+			cost = sub_6E24F6(
+				mapTile,
+				parameter1,
+				parameter2,
+				parameter3,
+				selected_tab);
+
+			if (cost != MONEY32_UNDEFINED)
+				break;
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) += 8;
+		}
+
+		RCT2_GLOBAL(0x00F64EB4, money32) = cost;
 		break;
 	case 1:
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 0);
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) = mapTile.x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) = mapTile.y;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) = mapTile.x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) = mapTile.y;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = 4;
+
+		map_invalidate_selection_rect();
+
+		// If no change in ghost placement
+		if ((RCT2_GLOBAL(0x00F64F0D, uint8) & (1 << 1)) &&
+			mapTile.x == RCT2_GLOBAL(0x00F64EC4, sint16) &&
+			mapTile.y == RCT2_GLOBAL(0x00F64EC6, sint16) &&
+			(parameter2 & 0xFF) == RCT2_GLOBAL(0x00F64F09, uint8)){
+			return;
+		}
+
+		scenery_remove_ghost_tool_placement();
+
+		cost = sub_6E24F6(
+			mapTile,
+			parameter1,
+			parameter2,
+			parameter3,
+			selected_tab);
+
+		RCT2_GLOBAL(0x00F64EB4, money32) = cost;
 		break;
 	case 2:
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 0);
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) = mapTile.x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) = mapTile.y;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) = mapTile.x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) = mapTile.y;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = 10 + parameter2 & 0xFF;
+
+		map_invalidate_selection_rect();
+
+		// If no change in ghost placement
+		if ((RCT2_GLOBAL(0x00F64F0D, uint8) & (1 << 2)) &&
+			mapTile.x == RCT2_GLOBAL(0x00F64EC4, sint16) &&
+			mapTile.y == RCT2_GLOBAL(0x00F64EC6, sint16) &&
+			(parameter2 & 0xFF) == RCT2_GLOBAL(0x00F64F11, uint8) &&
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) == RCT2_GLOBAL(0x00F64F0A, sint16)
+			){
+			return;
+		}
+
+		scenery_remove_ghost_tool_placement();
+
+		RCT2_GLOBAL(0x00F64F11, uint8) = (parameter2 & 0xFF);
+		RCT2_GLOBAL(0x00F64F0A, sint16) = RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16);
+
+		bl = 1;
+		if (RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) != 0 &&
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_TOOL_SHIFT_PRESSED, uint8) != 0){
+			bl = 20;
+		}
+
+		cost = 0;
+		for (; bl != 0; bl--){
+			cost = sub_6E24F6(
+				mapTile,
+				parameter1,
+				parameter2,
+				parameter3,
+				selected_tab);
+
+			if (cost != MONEY32_UNDEFINED)
+				break;
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) += 8;
+		}
+
+		RCT2_GLOBAL(0x00F64EB4, money32) = cost;
 		break;
 	case 3:
+		//6e29f2
 		break;
 	case 4:
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 0);
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) = mapTile.x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) = mapTile.y;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) = mapTile.x;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) = mapTile.y;
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = 4;
+
+		map_invalidate_selection_rect();
+
+		// If no change in ghost placement
+		if ((RCT2_GLOBAL(0x00F64F0D, uint8) & (1 << 4)) &&
+			mapTile.x == RCT2_GLOBAL(0x00F64EC4, sint16) &&
+			mapTile.y == RCT2_GLOBAL(0x00F64EC6, sint16) &&
+			(parameter2 & 0xFF) == RCT2_GLOBAL(0x00F64F09, uint8) &&
+			((parameter2 >> 8) & 0xFF) == RCT2_GLOBAL(0x00F64EC0, uint8)){
+			return;
+		}
+
+		scenery_remove_ghost_tool_placement();
+
+		cost = sub_6E24F6(
+			mapTile,
+			parameter1,
+			parameter2,
+			parameter3,
+			selected_tab);
+
+		RCT2_GLOBAL(0x00F64EB4, money32) = cost;
 		break;
 	}
 }
@@ -1991,7 +2155,7 @@ static void window_top_toolbar_tool_update()
 		top_toolbar_tool_update_water(x, y);
 		break;
 	case WIDX_SCENERY:
-		RCT2_CALLPROC_X(0x006E287B, x, y, 0, widgetIndex, (int)w, 0, 0);
+		top_toolbar_tool_update_scenery(x, y);
 		break;
 	}
 }

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -2093,7 +2093,64 @@ void top_toolbar_tool_update_scenery(sint16 x, sint16 y){
 		RCT2_GLOBAL(0x00F64EB4, money32) = cost;
 		break;
 	case 3:
-		//6e29f2
+		scenery = g_largeSceneryEntries[selected_scenery];
+		rct_xy16* selectedTile = gMapSelectionTiles;
+
+		for (rct_large_scenery_tile* tile = scenery->large_scenery.tiles; tile->x_offset != (sint16)0xFFFF; tile++){
+			rct_xy16 tileLocation = { 
+				.x = tile->x_offset, 
+				.y = tile->y_offset 
+			};
+
+			rotate_map_coordinates(&tileLocation.x, &tileLocation.y, (parameter1 >> 8) & 0xFF);
+
+			tileLocation.x += mapTile.x;
+			tileLocation.y += mapTile.y;
+
+			selectedTile->x = tileLocation.x;
+			selectedTile->y = tileLocation.y;
+			selectedTile++;
+		}
+		selectedTile->x = 0xFFFF;
+
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 1);
+		map_invalidate_map_selection_tiles();
+
+		// If no change in ghost placement
+		if ((RCT2_GLOBAL(0x00F64F0D, uint8) & (1 << 3)) &&
+			mapTile.x == RCT2_GLOBAL(0x00F64EC4, sint16) &&
+			mapTile.y == RCT2_GLOBAL(0x00F64EC6, sint16) &&
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) == RCT2_GLOBAL(0x00F64F0A, sint16) &&
+			(parameter3 & 0xFFFF) == RCT2_GLOBAL(0x00F64EDA, uint16)){
+			return;
+		}
+
+		scenery_remove_ghost_tool_placement();
+
+		RCT2_GLOBAL(0x00F64EDA, uint16) = (parameter3 & 0xFFFF);
+		RCT2_GLOBAL(0x00F64F0A, sint16) = RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16);
+
+		bl = 1;
+		if (RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) != 0 &&
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_TOOL_SHIFT_PRESSED, uint8) != 0){
+			bl = 20;
+		}
+
+		cost = 0;
+		for (; bl != 0; bl--){
+			cost = sub_6E24F6(
+				mapTile,
+				parameter1,
+				parameter2,
+				parameter3,
+				selected_tab);
+
+			if (cost != MONEY32_UNDEFINED)
+				break;
+			RCT2_GLOBAL(RCT2_ADDRESS_SCENERY_Z_COORDINATE, sint16) += 8;
+		}
+
+		RCT2_GLOBAL(0x00F64EB4, money32) = cost;
 		break;
 	case 4:
 		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 0);

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -729,7 +729,8 @@ static void repaint_scenery_tool_down(sint16 x, sint16 y, sint16 widgetIndex){
 	//RCT2_CALLPROC_X(0x6E2CC6, x, y, 0, widgetIndex, 0, 0, 0);
 	//return;
 	// ax, cx, bl
-	int grid_x, grid_y, type;
+	sint16 grid_x, grid_y;
+	int type;
 	// edx
 	rct_map_element* map_element;
 	uint16 flags =
@@ -1051,10 +1052,7 @@ void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid_x, sin
 			int interaction_type = 0;
 			rct_map_element* map_element;
 
-			int map_x, map_y;
-			get_map_coordinates_from_pos(x, y, flags, &map_x, &map_y, &interaction_type, &map_element, NULL);
-			*grid_x = (sint16)map_x;
-			*grid_y = (sint16)map_y;
+			get_map_coordinates_from_pos(x, y, flags, grid_x, grid_y, &interaction_type, &map_element, NULL);
 
 			if (interaction_type == VIEWPORT_INTERACTION_ITEM_NONE)
 			{
@@ -1133,10 +1131,7 @@ void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid_x, sin
 		int interaction_type = 0;
 		rct_map_element* map_element;
 
-		int map_x, map_y;
-		get_map_coordinates_from_pos(x, y, flags, &map_x, &map_y, &interaction_type, &map_element, NULL);
-		*grid_x = (sint16)map_x;
-		*grid_y = (sint16)map_y;
+		get_map_coordinates_from_pos(x, y, flags, grid_x, grid_y, &interaction_type, &map_element, NULL);
 
 		if (interaction_type == VIEWPORT_INTERACTION_ITEM_NONE)
 		{
@@ -1284,10 +1279,7 @@ void sub_6E1F34(sint16 x, sint16 y, uint16 selected_scenery, sint16* grid_x, sin
 		int interaction_type = 0;
 		rct_map_element* map_element;
 
-		int map_x, map_y;
-		get_map_coordinates_from_pos(x, y, flags, &map_x, &map_y, &interaction_type, &map_element, NULL);
-		*grid_x = (sint16)map_x;
-		*grid_y = (sint16)map_y;
+		get_map_coordinates_from_pos(x, y, flags, grid_x, grid_y, &interaction_type, &map_element, NULL);
 
 		if (interaction_type == VIEWPORT_INTERACTION_ITEM_NONE)
 		{

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -1539,7 +1539,7 @@ static void window_top_toolbar_scenery_tool_down(short x, short y, rct_window* w
 *
 *  rct2: 0x0068E213
 */
-void sub_68E213(sint16 x, sint16 y){
+void top_toolbar_tool_update_scenery_clear(sint16 x, sint16 y){
 	map_invalidate_selection_rect();
 	RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~(1 << 0);
 
@@ -1550,8 +1550,8 @@ void sub_68E213(sint16 x, sint16 y){
 		if (RCT2_GLOBAL(0x00F1AD62, money32) != MONEY32_UNDEFINED){
 			RCT2_GLOBAL(0x00F1AD62, money32) = MONEY32_UNDEFINED;
 			window_invalidate_by_class(WC_CLEAR_SCENERY);
-			return;
 		}
+		return;
 	}
 
 	uint8 state_changed = 0;
@@ -1606,10 +1606,10 @@ void sub_68E213(sint16 x, sint16 y){
 		return;
 
 	money32 cost = map_clear_scenery(
-		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16),
-		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16),
-		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16),
-		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16),
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) / 32,
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) / 32,
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) / 32,
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) / 32,
 		0);
 
 	if (RCT2_GLOBAL(0x00F1AD62, money32) != cost){
@@ -1633,11 +1633,11 @@ static void window_top_toolbar_tool_update()
 
 	switch (widgetIndex){
 	case WIDX_CLEAR_SCENERY:
-		sub_68E213(x, y);
+		top_toolbar_tool_update_scenery_clear(x, y);
 		break;
 	case WIDX_LAND:
 		if (LandPaintMode)
-			// Use the method that allows dragging the selection area
+			// Create a new version for this instance as scenery_clear is silly for this
 			RCT2_CALLPROC_X(0x0068E213, x, y, 0, widgetIndex, (int)w, 0, 0);
 		else
 			RCT2_CALLPROC_X(0x00664280, x, y, 0, widgetIndex, (int)w, 0, 0);

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -1919,6 +1919,52 @@ void top_toolbar_tool_update_water(sint16 x, sint16 y){
 }
 
 /**
+*
+*  rct2: 0x006E287B
+*/
+void top_toolbar_tool_update_scenery(sint16 x, sint16 y){
+	map_invalidate_selection_rect();
+	map_invalidate_map_selection_tiles();
+
+	RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~((1 << 0) | (1 << 1));
+
+	if (window_scenery_is_repaint_scenery_tool_on)
+		return;
+
+	sint16 selected_tab = window_scenery_selected_scenery_by_tab[window_scenery_active_tab_index];
+
+	if (selected_tab == -1){
+		scenery_remove_ghost_tool_placement();
+		return;
+	}
+
+	uint8 scenery_type = (selected_tab & 0xFF00) >> 8;
+	uint8 selected_scenery = selected_tab & 0xFF;
+	rct_xy16 mapTile = { 0 };
+	uint32 parameter1, parameter2, parameter3;
+
+	sub_6E1F34(x, y, selected_tab, &mapTile.x, &mapTile.y, &parameter1, &parameter2, &parameter3);
+
+	if (mapTile.x == (sint16)0x8000){
+		scenery_remove_ghost_tool_placement();
+		return;
+	}
+	
+	switch (scenery_type){
+	case 0:
+		break;
+	case 1:
+		break;
+	case 2:
+		break;
+	case 3:
+		break;
+	case 4:
+		break;
+	}
+}
+
+/**
  *
  *  rct2: 0x0066CB25
  */
@@ -1942,7 +1988,7 @@ static void window_top_toolbar_tool_update()
 			top_toolbar_tool_update_land(x, y);
 		break;
 	case WIDX_WATER:
-		RCT2_CALLPROC_X(0x006E6BDC, x, y, 0, widgetIndex, (int)w, 0, 0);
+		top_toolbar_tool_update_water(x, y);
 		break;
 	case WIDX_SCENERY:
 		RCT2_CALLPROC_X(0x006E287B, x, y, 0, widgetIndex, (int)w, 0, 0);

--- a/src/windows/top_toolbar.c
+++ b/src/windows/top_toolbar.c
@@ -1536,6 +1536,90 @@ static void window_top_toolbar_scenery_tool_down(short x, short y, rct_window* w
 }
 
 /**
+*
+*  rct2: 0x0068E213
+*/
+void sub_68E213(sint16 x, sint16 y){
+	map_invalidate_selection_rect();
+	RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) &= ~(1 << 0);
+
+	rct_xy16 mapTile = { 0 };
+	sub_688972(x, y, &mapTile.x, &mapTile.y, NULL);
+
+	if (mapTile.x == (sint16)0x8000){
+		if (RCT2_GLOBAL(0x00F1AD62, money32) != MONEY32_UNDEFINED){
+			RCT2_GLOBAL(0x00F1AD62, money32) = MONEY32_UNDEFINED;
+			window_invalidate_by_class(WC_CLEAR_SCENERY);
+			return;
+		}
+	}
+
+	uint8 state_changed = 0;
+
+	if (!(RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) & (1 << 0))){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_FLAGS, uint16) |= (1 << 0);
+		state_changed++;
+	}
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) != 4){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_TYPE, uint16) = 4;
+		state_changed++;
+	}
+
+	sint16 tool_size = RCT2_GLOBAL(RCT2_ADDRESS_LAND_TOOL_SIZE, sint16);
+	if (tool_size == 0)
+		tool_size = 1;
+
+	sint16 tool_length = (tool_size - 1) * 32;
+
+	// Move to tool bottom left
+	mapTile.x -= (tool_size - 1) * 16;
+	mapTile.y -= (tool_size - 1) * 16;
+	mapTile.x &= 0xFFE0;
+	mapTile.y &= 0xFFE0;
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) != mapTile.x){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16) = mapTile.x;
+		state_changed++;
+	}
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) != mapTile.y){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16) = mapTile.y;
+		state_changed++;
+	}
+
+	mapTile.x += tool_length;
+	mapTile.y += tool_length;
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) != mapTile.x){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16) = mapTile.x;
+		state_changed++;
+	}
+
+	if (RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) != mapTile.y){
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16) = mapTile.y;
+		state_changed++;
+	}
+
+	map_invalidate_selection_rect();
+	if (!state_changed)
+		return;
+
+	money32 cost = map_clear_scenery(
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_X, sint16),
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_A_Y, sint16),
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_X, sint16),
+		RCT2_GLOBAL(RCT2_ADDRESS_MAP_SELECTION_B_Y, sint16),
+		0);
+
+	if (RCT2_GLOBAL(0x00F1AD62, money32) != cost){
+		RCT2_GLOBAL(0x00F1AD62, money32) = cost;
+		window_invalidate_by_class(WC_CLEAR_SCENERY);
+		return;
+	}
+}
+
+/**
  *
  *  rct2: 0x0066CB25
  */
@@ -1549,7 +1633,7 @@ static void window_top_toolbar_tool_update()
 
 	switch (widgetIndex){
 	case WIDX_CLEAR_SCENERY:
-		RCT2_CALLPROC_X(0x0068E213, x, y, 0, widgetIndex, (int)w, 0, 0);
+		sub_68E213(x, y);
 		break;
 	case WIDX_LAND:
 		if (LandPaintMode)

--- a/src/windows/viewport.c
+++ b/src/windows/viewport.c
@@ -153,7 +153,7 @@ static void window_viewport_mouseup()
 {
 	short widgetIndex;
 	rct_window *w, *mainWindow;
-	int x, y;
+	sint16 x, y;
 
 	window_widget_get_registers(w, widgetIndex);
 

--- a/src/world/footpath.c
+++ b/src/world/footpath.c
@@ -493,9 +493,11 @@ void footpath_get_coordinates_from_pos(int screenX, int screenY, int *x, int *y,
 	int z, interactionType;
 	rct_map_element *myMapElement;
 	rct_viewport *viewport;
-	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_FOOTPATH, x, y, &interactionType, &myMapElement, &viewport);
+	rct_xy16 map_pos = { 0 };
+
+	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_FOOTPATH, &map_pos.x, &map_pos.y, &interactionType, &myMapElement, &viewport);
 	if (interactionType != VIEWPORT_INTERACTION_ITEM_FOOTPATH || !(viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL))) {
-		get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN, x, y, &interactionType, &myMapElement, &viewport);
+		get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN, &map_pos.x, &map_pos.y, &interactionType, &myMapElement, &viewport);
 		if (interactionType == VIEWPORT_INTERACTION_ITEM_NONE) {
 			if (x != NULL) *x = 0x8000;
 			return;
@@ -512,16 +514,15 @@ void footpath_get_coordinates_from_pos(int screenX, int screenY, int *x, int *y,
 	}
 
 	RCT2_GLOBAL(0x00F1AD3C, uint16) = z;
-	RCT2_GLOBAL(0x00F1AD34, sint16) = *x;
-	RCT2_GLOBAL(0x00F1AD36, sint16) = *y;
-	RCT2_GLOBAL(0x00F1AD38, sint16) = *x + 31;
-	RCT2_GLOBAL(0x00F1AD3A, sint16) = *y + 31;
+	RCT2_GLOBAL(0x00F1AD34, sint16) = map_pos.x;
+	RCT2_GLOBAL(0x00F1AD36, sint16) = map_pos.y;
+	RCT2_GLOBAL(0x00F1AD38, sint16) = map_pos.x + 31;
+	RCT2_GLOBAL(0x00F1AD3A, sint16) = map_pos.y + 31;
 
-	*x += 16;
-	*y += 16;
+	map_pos.x += 16;
+	map_pos.y += 16;
 
 	rct_xy16 start_vp_pos = screen_coord_to_viewport_coord(viewport, screenX, screenY);
-	rct_xy16 map_pos = { *x, *y };
 
 	for (int i = 0; i < 5; i++) {
 		if (RCT2_GLOBAL(0x00F1AD3E, uint8) != 6) {
@@ -573,7 +574,12 @@ void footpath_bridge_get_info_from_pos(int screenX, int screenY, int *x, int *y,
 	// First check if we point at an entrance or exit. In that case, we would want the path coming from the entrance/exit.
 	int interactionType;
 	rct_viewport *viewport;
-	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_RIDE, x, y, &interactionType, mapElement, &viewport);
+
+	rct_xy16 map_pos = { 0 };
+	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_RIDE, &map_pos.x, &map_pos.y, &interactionType, mapElement, &viewport);
+	*x = map_pos.x;
+	*y = map_pos.y;
+
 	if (interactionType == VIEWPORT_INTERACTION_ITEM_RIDE
 		&& viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL)
 		&& map_element_get_type(*mapElement) == MAP_ELEMENT_TYPE_ENTRANCE) {
@@ -588,7 +594,9 @@ void footpath_bridge_get_info_from_pos(int screenX, int screenY, int *x, int *y,
 		}
 	}
 	
-	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_RIDE & VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN, x, y, &interactionType, mapElement, &viewport);
+	get_map_coordinates_from_pos(screenX, screenY, VIEWPORT_INTERACTION_MASK_RIDE & VIEWPORT_INTERACTION_MASK_FOOTPATH & VIEWPORT_INTERACTION_MASK_TERRAIN, &map_pos.x, &map_pos.y, &interactionType, mapElement, &viewport);
+	*x = map_pos.x;
+	*y = map_pos.y;
 	if (interactionType == VIEWPORT_INTERACTION_ITEM_RIDE && map_element_get_type(*mapElement) == MAP_ELEMENT_TYPE_ENTRANCE) {
 		int ebp = (*mapElement)->properties.entrance.type << 4;
 		int bl = (*mapElement)->properties.entrance.index & 0xF; // Seems to be always 0?

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -1560,68 +1560,59 @@ void game_command_lower_land(int* eax, int* ebx, int* ecx, int* edx, int* esi, i
 	*ebx = cost;
 }
 
-/**
- *
- *  rct2: 0x006E66A0
- */
-void game_command_raise_water(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp)
-{
-	int ax = (uint16)*eax;
-	int ay = (uint16)*ecx;
-	int bx = (uint16)*edi;
-	int by = (uint16)*ebp;
-
-	int cost = 0;
+money32 raise_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags){
+	money32 cost = 0;
 
 	uint8 max_height = 0xFF;
 
-	for(int yi = ay; yi <= by; yi += 32){
-		for(int xi = ax; xi <= bx; xi += 32){
+	for (int yi = y0; yi <= y1; yi += 32){
+		for (int xi = x0; xi <= x1; xi += 32){
 			rct_map_element* map_element = map_get_surface_element_at(xi / 32, yi / 32);
 			uint8 height = map_element->base_height;
-			if(map_element->properties.surface.terrain & 0x1F){
+			if (map_element->properties.surface.terrain & 0x1F){
 				height = (map_element->properties.surface.terrain & 0x1F) * 2;
 			}
-			if(max_height > height){
+			if (max_height > height){
 				max_height = height;
 			}
 		}
 	}
 
-	for(int yi = ay; yi <= by; yi += 32){
-		for(int xi = ax; xi <= bx; xi += 32){
+	for (int yi = y0; yi <= y1; yi += 32){
+		for (int xi = x0; xi <= x1; xi += 32){
 			rct_map_element* map_element = map_get_surface_element_at(xi / 32, yi / 32);
-			
-			if(map_element->base_height <= max_height){
+
+			if (map_element->base_height <= max_height){
 				uint8 height = (map_element->properties.surface.terrain & 0x1F);
-				if(height){
+				if (height){
 					height *= 2;
-					if(height > max_height){
+					if (height > max_height){
 						continue;
 					}
 					height += 2;
-				}else{
+				}
+				else{
 					height = map_element->base_height + 2;
 				}
-				int eax2 = xi, ebx2 = *ebx, ecx2 = yi, edx2 = (max_height << 8) + height, esi2, edi2, ebp2;
-				ebx2 = game_do_command_p(GAME_COMMAND_16, &eax2, &ebx2, &ecx2, &edx2, &esi2, &edi2, &ebp2);
-				if(ebx2 == MONEY32_UNDEFINED){
-					*ebx = MONEY32_UNDEFINED;
-					return;
-				}else{
-					cost += ebx2;
+
+				money32 cost2 = game_do_command(GAME_COMMAND_16, xi, flags, yi, (max_height << 8) + height, 0, 0, 0);
+				if (cost2 == MONEY32_UNDEFINED){
+					return MONEY32_UNDEFINED;
+				}
+				else{
+					cost += cost2;
 				}
 			}
 		}
 	}
-	if(*ebx & GAME_COMMAND_FLAG_APPLY){
-		int x = ((ax + bx) / 2) + 16;
-		int y = ((ay + by) / 2) + 16;
+	if (flags & GAME_COMMAND_FLAG_APPLY){
+		int x = ((x0 + x1) / 2) + 16;
+		int y = ((y0 + y1) / 2) + 16;
 		int z = map_element_height(x, y);
 		sint16 water_height_z = z >> 16;
 		sint16 base_height_z = z;
 		z = water_height_z;
-		if(!z){
+		if (!z){
 			z = base_height_z;
 		}
 		RCT2_GLOBAL(0x009DEA5E, uint32) = x;
@@ -1629,7 +1620,79 @@ void game_command_raise_water(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
 		RCT2_GLOBAL(0x009DEA62, uint32) = z;
 		sound_play_panned(SOUND_LAYING_OUT_WATER, 0x8001, x, y, z);
 	}
-	*ebx = cost;
+	return cost;
+}
+
+/**
+ *
+ *  rct2: 0x006E66A0
+ */
+void game_command_raise_water(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp)
+{
+	*ebx = raise_water(
+		(sint16)*eax,
+		(sint16)*ecx,
+		(sint16)*edi,
+		(sint16)*ebp,
+		(uint8)*ebx);
+}
+
+money32 lower_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags){
+	money32 cost = 0;
+
+	uint8 min_height = 0;
+
+	for (int yi = y0; yi <= y1; yi += 32){
+		for (int xi = x0; xi <= x1; xi += 32){
+			rct_map_element* map_element = map_get_surface_element_at(xi / 32, yi / 32);
+
+			uint8 height = map_element->properties.surface.terrain & 0x1F;
+			if (height){
+				height *= 2;
+				if (height > min_height){
+					min_height = height;
+				}
+			}
+		}
+	}
+
+	for (int yi = y0; yi <= y1; yi += 32){
+		for (int xi = x0; xi <= x1; xi += 32){
+			rct_map_element* map_element = map_get_surface_element_at(xi / 32, yi / 32);
+
+			uint8 height = (map_element->properties.surface.terrain & 0x1F);
+			if (height){
+				height *= 2;
+				if (height < min_height){
+					continue;
+				}
+				height -= 2;
+				int cost2 = game_do_command(xi, flags, yi, (min_height << 8) + height, GAME_COMMAND_16, 0, 0);
+				if (cost2 == MONEY32_UNDEFINED){
+					return MONEY32_UNDEFINED;
+				}
+				else{
+					cost += cost2;
+				}
+			}
+		}
+	}
+	if (flags & GAME_COMMAND_FLAG_APPLY){
+		int x = ((x0 + x1) / 2) + 16;
+		int y = ((y0 + y1) / 2) + 16;
+		int z = map_element_height(x, y);
+		sint16 water_height_z = z >> 16;
+		sint16 base_height_z = z;
+		z = water_height_z;
+		if (!z){
+			z = base_height_z;
+		}
+		RCT2_GLOBAL(0x009DEA5E, uint32) = x;
+		RCT2_GLOBAL(0x009DEA60, uint32) = y;
+		RCT2_GLOBAL(0x009DEA62, uint32) = z;
+		sound_play_panned(SOUND_LAYING_OUT_WATER, 0x8001, x, y, z);
+	}
+	return cost;
 }
 
 /**
@@ -1638,66 +1701,12 @@ void game_command_raise_water(int* eax, int* ebx, int* ecx, int* edx, int* esi, 
  */
 void game_command_lower_water(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp)
 {
-	int ax = (uint16)*eax;
-	int ay = (uint16)*ecx;
-	int bx = (uint16)*edi;
-	int by = (uint16)*ebp;
-
-	int cost = 0;
-
-	uint8 min_height = 0;
-
-	for(int yi = ay; yi <= by; yi += 32){
-		for(int xi = ax; xi <= bx; xi += 32){
-			rct_map_element* map_element = map_get_surface_element_at(xi / 32, yi / 32);
-
-			uint8 height = map_element->properties.surface.terrain & 0x1F;
-			if(height){
-				height *= 2;
-				if(height > min_height){
-					min_height = height;
-				}
-			}
-		}
-	}
-
-	for(int yi = ay; yi <= by; yi += 32){
-		for(int xi = ax; xi <= bx; xi += 32){
-			rct_map_element* map_element = map_get_surface_element_at(xi / 32, yi / 32);
-			
-			uint8 height = (map_element->properties.surface.terrain & 0x1F);
-			if(height){
-				height *= 2;
-				if(height < min_height){
-					continue;
-				}
-				height -= 2;
-				int ebx2 = game_do_command(xi, *ebx, yi, (min_height << 8) + height, GAME_COMMAND_16, 0, 0);
-				if(ebx2 == MONEY32_UNDEFINED){
-					*ebx = MONEY32_UNDEFINED;
-					return;
-				}else{
-					cost += ebx2;
-				}
-			}
-		}
-	}
-	if(*ebx & GAME_COMMAND_FLAG_APPLY){
-		int x = ((ax + bx) / 2) + 16;
-		int y = ((ay + by) / 2) + 16;
-		int z = map_element_height(x, y);
-		sint16 water_height_z = z >> 16;
-		sint16 base_height_z = z;
-		z = water_height_z;
-		if(!z){
-			z = base_height_z;
-		}
-		RCT2_GLOBAL(0x009DEA5E, uint32) = x;
-		RCT2_GLOBAL(0x009DEA60, uint32) = y;
-		RCT2_GLOBAL(0x009DEA62, uint32) = z;
-		sound_play_panned(SOUND_LAYING_OUT_WATER, 0x8001, x, y, z);
-	}
-	*ebx = cost;
+	*ebx = lower_water(
+		(sint16)*eax, 
+		(sint16)*ecx, 
+		(sint16)*edi, 
+		(sint16)*ebp, 
+		(uint8)*ebx);
 }
 
 /**

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -1732,6 +1732,12 @@ void game_command_remove_fence(int* eax, int* ebx, int* ecx, int* edx, int* esi,
 			return;
 		}
 	}
+
+	if (!(*ebx & GAME_COMMAND_FLAG_APPLY)){
+		*ebx = 0;
+		return;
+	}
+
 	rct_scenery_entry* scenery_entry = RCT2_ADDRESS(RCT2_ADDRESS_WALL_SCENERY_ENTRIES, rct_scenery_entry*)[map_element->properties.fence.type];
 	if(scenery_entry->wall.var_0D != 0xFF){
 		rct_banner* banner = &gBanners[map_element->properties.fence.item[0]];

--- a/src/world/map.c
+++ b/src/world/map.c
@@ -1595,7 +1595,7 @@ money32 raise_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags){
 					height = map_element->base_height + 2;
 				}
 
-				money32 cost2 = game_do_command(GAME_COMMAND_16, xi, flags, yi, (max_height << 8) + height, 0, 0, 0);
+				money32 cost2 = game_do_command(xi, flags, yi, (max_height << 8) + height, GAME_COMMAND_16, 0, 0);
 				if (cost2 == MONEY32_UNDEFINED){
 					return MONEY32_UNDEFINED;
 				}

--- a/src/world/map.h
+++ b/src/world/map.h
@@ -279,6 +279,7 @@ rct_map_element *map_element_insert(int x, int y, int z, int flags);
 int map_can_construct_with_clear_at(int x, int y, int zLow, int zHigh, void *clearFunc, uint8 bl);
 int map_can_construct_at(int x, int y, int zLow, int zHigh, uint8 bl);
 int sub_6BA278(int ebx);
+money32 map_clear_scenery(int x0, int y0, int x1, int y1, int flags);
 
 void game_command_remove_scenery(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp);
 void game_command_remove_large_scenery(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp);

--- a/src/world/map.h
+++ b/src/world/map.h
@@ -279,6 +279,7 @@ rct_map_element *map_element_insert(int x, int y, int z, int flags);
 int map_can_construct_with_clear_at(int x, int y, int zLow, int zHigh, void *clearFunc, uint8 bl);
 int map_can_construct_at(int x, int y, int zLow, int zHigh, uint8 bl);
 int sub_6BA278(int ebx);
+void rotate_map_coordinates(sint16* x, sint16* y, uint8 rotation);
 money32 map_clear_scenery(int x0, int y0, int x1, int y1, int flags);
 money32 lower_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags);
 money32 raise_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags);

--- a/src/world/map.h
+++ b/src/world/map.h
@@ -280,6 +280,8 @@ int map_can_construct_with_clear_at(int x, int y, int zLow, int zHigh, void *cle
 int map_can_construct_at(int x, int y, int zLow, int zHigh, uint8 bl);
 int sub_6BA278(int ebx);
 money32 map_clear_scenery(int x0, int y0, int x1, int y1, int flags);
+money32 lower_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags);
+money32 raise_water(sint16 x0, sint16 y0, sint16 x1, sint16 y1, uint8 flags);
 
 void game_command_remove_scenery(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp);
 void game_command_remove_large_scenery(int* eax, int* ebx, int* ecx, int* edx, int* esi, int* edi, int* ebp);


### PR DESCRIPTION
This is all of the tool update functions that for whatever reason are handled by the top toolbar.

With this reversed I think @Gericom 's viewport_banner_paint_setup can be renabled as these were the functions that were resetting the viewport display setup. I haven't renabled the banner code in this PR as I want to check that every case that would force it into the old code has been taken care of.

Ghost scenery is now placed using OpenRCT2 game commands (If reversed).
