### PR TITLE
Add dithering to sprite importer

### DIFF
--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -60,6 +60,7 @@ int cmdline_run(const char **argv, int argc)
 		OPT_HELP(),
 		OPT_BOOLEAN('v', "version", &version, "show version information and exit"),
 		OPT_BOOLEAN(0, "verbose", &verbose, "log verbose messages"),
+		OPT_INTEGER('m', "mode", &sprite_mode, "the type of sprite conversion. 0 = default, 1 = simple closest pixel match, 2 = dithering"),
 		OPT_END()
 	};
 

--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -26,6 +26,8 @@
 /** The exit code for OpenRCT2 when it exits. */
 extern int gExitCode;
 
+int sprite_mode;
+
 int cmdline_run(const char **argv, int argc);
 int cmdline_for_sprite(const char **argv, int argc);
 

--- a/src/cmdline_sprite.c
+++ b/src/cmdline_sprite.c
@@ -176,7 +176,7 @@ bool sprite_file_export(int spriteIndex, const char *outPath)
 }
 
 bool is_transparent_pixel(sint16 *colour){
-	return colour[3] == 0;
+	return colour[3] < 128;
 }
 
 // Returns true if pixel index is an index not used for remapping
@@ -218,7 +218,7 @@ int get_closest_palette_index(sint16 *colour){
 
 int get_palette_index(sint16 *colour)
 {	
-	if (colour[3] < 128)
+	if (is_transparent_pixel(colour))
 		return -1;
 
 	for (int i = 0; i < 256; i++) {
@@ -261,13 +261,11 @@ bool sprite_file_import(const char *path, rct_g1_element *outElement, uint8 **ou
 
 	// A larger range is needed for proper dithering
 	sint16 *src = malloc(height * width * 4 * 2);
-	for (int x = 0; x < height * width * 4; x++){
+	for (uint32 x = 0; x < height * width * 4; x++){
 		src[x] = (sint16) pixels[x];
 	}
 
 	uint8 *dst = buffer + (height * 2);
-
-	int dos = 0;
 	
 	for (unsigned int y = 0; y < height; y++) {
 		rle_code *previousCode, *currentCode;
@@ -293,16 +291,6 @@ bool sprite_file_import(const char *path, rct_g1_element *outElement, uint8 **ou
 					sint16 dr = src[0] - (sint16)(spriteFilePalette[paletteIndex].r);
 					sint16 dg = src[1] - (sint16)(spriteFilePalette[paletteIndex].g);
 					sint16 db = src[2] - (sint16)(spriteFilePalette[paletteIndex].b);
-
-					if (dos < 40){
-						printf("Original: %d, %d, %d\n", src[0], src[1], src[2]);
-						printf("Chosen: %d, %d, %d\n", spriteFilePalette[paletteIndex].r, spriteFilePalette[paletteIndex].g, spriteFilePalette[paletteIndex].b);
-						printf("%d - %d = %d", src[0], spriteFilePalette[paletteIndex].r, src[0] - spriteFilePalette[paletteIndex].r);
-						printf("Pixel: %d.\n", paletteIndex);
-						printf("%d, %d, %d\n", dr, dg, db);
-						puts("");
-						dos++;
-					}
 
 					if (x + 1 < width){
 						if (!is_transparent_pixel(src + 4) && is_changable_pixel(get_palette_index(src + 4))){

--- a/src/cmdline_sprite.c
+++ b/src/cmdline_sprite.c
@@ -330,7 +330,7 @@ bool sprite_file_import(const char *path, rct_g1_element *outElement, uint8 **ou
 				}
 
 			src += 4;
-			if (is_transparent_pixel(src)) {
+			if (paletteIndex == -1) {
 				if (pixels != 0) {
 					x--;
 					src -= 4;


### PR DESCRIPTION
Adds two new modes to import files. To specify the mode, use the option -m with either 0, 1 or 2. It defaults to 0. The mode can be used when using import or build.

* Mode 0: default. This mode behaves the same as the importer did before. Any pixels not present in the colour scheme will be ignored.
* Mode 1: closest. This mode will change all pixels to the closest pixel in the palette. Already converted images will be unaffected.
* Mode 2: dithering. This mode will use Floyd-Steinberg dithering to make the image look close to the original while converting to the colour palette. Already converted images will be unaffected.

Both converting modes will ignore transparent pixels (a < 128) and remapping pixels. They will stay the same as in the original and won't affect neighboring pixels.