### PR TITLE
Sprite tool now can export all sprites in a file

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -40,6 +40,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * (KingHual) - Housecleaning
 * Alexander Overvoorde (Overv) - Misc.
 * (eezstreet) - Misc.
+* Thomas den Hollander (ThomasdenH) - Misc.
 
 ## Bug fixes
 * (halfbro)

--- a/src/cmdline_sprite.c
+++ b/src/cmdline_sprite.c
@@ -1,9 +1,9 @@
 #include <lodepng/lodepng.h>
+#include <math.h>
 #include "cmdline.h"
 #include "drawing/drawing.h"
+#include "platform/platform.h"
 #include "util/util.h"
-#include <math.h>
-#include "platform\platform.h"
 
 #define MODE_DEFAULT 0
 #define MODE_CLOSEST 1


### PR DESCRIPTION
Use the command exportall to export all the sprites in a file to the specified directory:

    openrct2 sprite exportall g1.dat out\