### PR TITLE
Textbox Widget

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -736,6 +736,12 @@ static void input_widget_left(int x, int y, rct_window *w, int widgetIndex)
 	if (widgetIndex == -1)
 		return;
 
+	if (windowClass != gCurrentTextBox.window.classification ||
+		windowNumber != gCurrentTextBox.window.number ||
+		widgetIndex != gCurrentTextBox.widget_index) {
+		window_cancel_textbox();
+	}
+
 	widget = &w->widgets[widgetIndex];
 
 	switch (widget->type) {
@@ -1173,8 +1179,10 @@ void game_handle_keyboard_input()
 
 		// Reserve backtick for console
 		if (key == SDL_SCANCODE_GRAVE) {
-			if (gConfigGeneral.debugging_tools || gConsoleOpen)
+			if (gConfigGeneral.debugging_tools || gConsoleOpen) {
+				window_cancel_textbox();
 				console_toggle();
+			}
 			continue;
 		} else if (gConsoleOpen) {
 			console_input(key);
@@ -1195,7 +1203,7 @@ void game_handle_keyboard_input()
 			if (w != NULL){
 				((void(*)(int, rct_window*))w->event_handlers[WE_TEXT_INPUT])(key, w);
 			}
-			else {
+			else if (!gUsingWidgetTextBox) {
 				keyboard_shortcut_handle(key);
 			}
 		}
@@ -1374,7 +1382,7 @@ void game_handle_key_scroll()
 	rct_window *textWindow;
 
 	textWindow = window_find_by_class(WC_TEXTINPUT);
-	if (textWindow) return;
+	if (textWindow || gUsingWidgetTextBox) return;
 
 	scrollX = 0;
 	scrollY = 0;

--- a/src/interface/widget.h
+++ b/src/interface/widget.h
@@ -50,7 +50,8 @@ typedef enum {
 	WWT_CHECKBOX = 23,
 	WWT_24,
 	WWT_25,
-	WWT_LAST = 26,
+	WWT_TEXT_BOX = 26,
+	WWT_LAST = 27,
 } WINDOW_WIDGET_TYPES;
 #define WIDGETS_END		WWT_LAST, 0, 0, 0, 0, 0, 0, 0
 

--- a/src/interface/window.h
+++ b/src/interface/window.h
@@ -31,6 +31,10 @@
 struct rct_window;
 union rct_window_event;
 extern uint8 TextInputDescriptionArgs[8];
+extern char gTextBoxInput[512];
+extern int gMaxTextBoxInputLength;
+extern int gTextBoxFrameNo;
+extern bool gUsingWidgetTextBox;
 
 typedef void wndproc(struct rct_window*, union rct_window_event*);
 
@@ -46,6 +50,8 @@ typedef struct {
 	window_identifier window;
 	int widget_index;
 } widget_identifier;
+
+extern widget_identifier gCurrentTextBox;
 
 /**
  * Widget structure
@@ -604,6 +610,11 @@ void textinput_cancel();
 
 void window_move_and_snap(rct_window *w, int newWindowX, int newWindowY, int snapProximity);
 int window_can_resize(rct_window *w);
+
+void window_start_textbox(rct_window *call_w, int call_widget, rct_string_id existing_text, uint32 existing_args, int maxLength);
+void window_cancel_textbox();
+void window_update_textbox_caret();
+void window_update_textbox();
 
 #ifdef _MSC_VER
 	#define window_get_register(w)														\

--- a/src/platform/shared.c
+++ b/src/platform/shared.c
@@ -389,6 +389,7 @@ void platform_process_messages()
 				gTextInputCursorPosition--;
 				gTextInputLength--;
 				console_refresh_caret();
+				window_update_textbox();
 			}
 			if (e.key.keysym.sym == SDLK_END){
 				gTextInputCursorPosition = gTextInputLength;
@@ -403,6 +404,10 @@ void platform_process_messages()
 				gTextInput[gTextInputMaxLength - 1] = '\0';
 				gTextInputLength--;
 				console_refresh_caret();
+				window_update_textbox();
+			}
+			if (e.key.keysym.sym == SDLK_RETURN && gTextInput) {
+				window_cancel_textbox();
 			}
 			if (e.key.keysym.sym == SDLK_LEFT && gTextInput){
 				if (gTextInputCursorPosition) gTextInputCursorPosition--;
@@ -432,7 +437,7 @@ void platform_process_messages()
 
 						gTextInputCursorPosition++;
 					}
-
+					window_update_textbox();
 				}
 			}
 			break;
@@ -479,6 +484,7 @@ void platform_process_messages()
 
 				gTextInputCursorPosition++;
 				console_refresh_caret();
+				window_update_textbox();
 			}
 			break;
 		default:

--- a/src/windows/editor_object_selection.c
+++ b/src/windows/editor_object_selection.c
@@ -115,7 +115,7 @@ static rct_widget window_editor_object_selection_widgets[] = {
 	{ WWT_FLATBTN,			1,	391,	504,	46,		159,	0xFFFFFFFF,						STR_NONE },
 	{ WWT_DROPDOWN_BUTTON,	0,	384,	595,	24,		35,		STR_INSTALL_NEW_TRACK_DESIGN,	STR_INSTALL_NEW_TRACK_DESIGN_TIP },
 	{ WWT_DROPDOWN_BUTTON,	0,	350,	463,	23,		34,		5261,							5265 },
-	{ WWT_DROPDOWN_BUTTON,	1,	4,		214,	46,		57,		STR_NONE,						STR_NONE },
+	{ WWT_TEXT_BOX,			1,	4,		214,	46,		57,		(uint32)_filter_string,			STR_NONE },
 	{ WWT_DROPDOWN_BUTTON,	1,	218,	287,	46,		57,		5277,							STR_NONE },
 	{ WIDGETS_END }
 };
@@ -130,6 +130,7 @@ static void window_editor_object_selection_close();
 static void window_editor_object_selection_mouseup();
 static void window_editor_object_selection_mousedown(int widgetIndex, rct_window*w, rct_widget* widget);
 static void window_editor_object_selection_dropdown();
+static void window_editor_object_selection_update(rct_window *w);
 static void window_editor_object_selection_scrollgetsize();
 static void window_editor_object_selection_scroll_mousedown();
 static void window_editor_object_selection_scroll_mouseover();
@@ -146,7 +147,7 @@ static void* window_editor_object_selection_events[] = {
 	(void*)window_editor_object_selection_mousedown,
 	(void*)window_editor_object_selection_dropdown,
 	(void*)window_editor_object_selection_emptysub,
-	(void*)window_editor_object_selection_emptysub,
+	(void*)window_editor_object_selection_update,
 	(void*)window_editor_object_selection_emptysub,
 	(void*)window_editor_object_selection_emptysub,
 	(void*)window_editor_object_selection_emptysub,
@@ -356,7 +357,8 @@ static void window_editor_object_selection_mouseup()
 		window_loadsave_open(LOADSAVETYPE_LOAD | LOADSAVETYPE_TRACK);
 		break;
 	case WIDX_FILTER_STRING_BUTTON:
-		window_text_input_open(w, widgetIndex, 5275, 5276, 1170, (uint32)_filter_string, 40);
+		//window_text_input_open(w, widgetIndex, 5275, 5276, 1170, (uint32)_filter_string, 40);
+		window_start_textbox(w, widgetIndex, 1170, (uint32)_filter_string, 40);
 		break;
 	case WIDX_FILTER_CLEAR_BUTTON:
 		memset(_filter_string, 0, sizeof(_filter_string));
@@ -698,7 +700,7 @@ static void window_editor_object_selection_paint()
 
 	rct_stex_entry* stex_entry = RCT2_GLOBAL(RCT2_ADDRESS_SCENARIO_TEXT_TEMP_CHUNK, rct_stex_entry*);
 
-	gfx_fill_rect_inset(dpi,
+	/*gfx_fill_rect_inset(dpi,
 		w->x + window_editor_object_selection_widgets[WIDX_FILTER_STRING_BUTTON].left,
 		w->y + window_editor_object_selection_widgets[WIDX_FILTER_STRING_BUTTON].top,
 		w->x + window_editor_object_selection_widgets[WIDX_FILTER_STRING_BUTTON].right,
@@ -716,7 +718,7 @@ static void window_editor_object_selection_paint()
 		w->x + window_editor_object_selection_widgets[WIDX_FILTER_STRING_BUTTON].left + 1,
 		w->y + window_editor_object_selection_widgets[WIDX_FILTER_STRING_BUTTON].top,
 		w->x + window_editor_object_selection_widgets[WIDX_FILTER_STRING_BUTTON].right
-		);
+		);*/
 
 	if (w->selected_list_item == -1 || stex_entry == NULL)
 		return;
@@ -1034,6 +1036,15 @@ static void editor_load_selected_objects()
 	}
 }
 
+static void window_editor_object_selection_update(rct_window *w)
+{
+	if (gCurrentTextBox.window.classification == w->classification &&
+		gCurrentTextBox.window.number == w->number) {
+		window_update_textbox_caret();
+		widget_invalidate(w, WIDX_FILTER_STRING_BUTTON);
+	}
+}
+
 static void window_editor_object_selection_textinput()
 {
 	uint8 result;
@@ -1045,6 +1056,10 @@ static void window_editor_object_selection_textinput()
 
 	if (widgetIndex != WIDX_FILTER_STRING_BUTTON || !result)
 		return;
+
+	if (strcmp(_filter_string, text) == 0)
+		return;
+
 	if (strlen(text) == 0) {
 		memset(_filter_string, 0, sizeof(_filter_string));
 	}


### PR DESCRIPTION
Object Selection window now uses textbox widget and updates the list as you're typing.

The image value of the text box widget should be set to the char string of the textbox.
Call window_start_textbox(...) on mouse up for textbox widgets to start typing.
Use the text input event to catch changes to the textbox text.
See editor_object_selection.c to for more informtion on how to use the textbox widget.