### PR TITLE
Fix original windows crashing

### DIFF
--- a/src/interface/widget.h
+++ b/src/interface/widget.h
@@ -50,8 +50,8 @@ typedef enum {
 	WWT_CHECKBOX = 23,
 	WWT_24,
 	WWT_25,
-	WWT_TEXT_BOX = 26,
-	WWT_LAST = 27,
+	WWT_TEXT_BOX = 27,
+	WWT_LAST = 26,
 } WINDOW_WIDGET_TYPES;
 #define WIDGETS_END		WWT_LAST, 0, 0, 0, 0, 0, 0, 0
 


### PR DESCRIPTION
Due to the change in WWT_LAST assignment any windows that were not finished would access invalid memory and kick up a fuss causing #1249.