### PR TITLE
Correctly draw invisible entrances

### DIFF
--- a/src/interface/viewport.c
+++ b/src/interface/viewport.c
@@ -1185,6 +1185,11 @@ void sub_68B35F(int ax, int cx)
 						RCT2_CALLPROC_X(0x6B9CC4, 0, 0, direction, dx, (int)map_element, 0, 0);
 						break;
 					default:
+						// This is a little hack for taking care of undefined map_elements
+						// 8cars MOM used a dirty version of this to skip drawing certain elements
+						if (map_element_is_last_for_tile(map_element))
+							return;
+						map_element++;
 						break;
 					}
 					RCT2_GLOBAL(0x9DE574, uint32_t) = dword_9DE574;


### PR DESCRIPTION
For a lengthy reason as to how this worked in RCT2 see #1243. New version skips bad map_elements (and the next one). Possibly it should return as soon as it finds a bad map_element but I'm not too sure.