### PR TITLE
Fixed fire prompt transparency issue

### DIFF
--- a/src/windows/staff_fire_prompt.c
+++ b/src/windows/staff_fire_prompt.c
@@ -99,6 +99,8 @@ void window_staff_fire_prompt_open(rct_peep* peep){
 
 	window_init_scroll_widgets(w);
 
+	colour_scheme_update(w);
+
 	w->flags |= WF_TRANSPARENT;
 	w->number = peep->sprite_index;
 }


### PR DESCRIPTION
Staff fire prompt will no longer randomly be not transparent when it should be.