### PR TITLE
Fix crash on loading certain sv6 files

### DIFF
--- a/src/title.c
+++ b/src/title.c
@@ -213,7 +213,8 @@ static int title_load_park(const char *path)
 	window_invalidate(w);
 	reset_all_sprite_quadrant_placements();
 	window_new_ride_init_vars();
-	sub_684AC3();
+	if (_strcmpi(path_get_extension(path), ".sv6") != 0)
+		sub_684AC3();
 	RCT2_CALLPROC_EBPSAFE(0x006DFEE4);
 	news_item_init_queue();
 	gfx_invalidate_screen();


### PR DESCRIPTION
Sub_684AC3 was incorrectly being called on .sv6 load. Not completely sure on the function of 684ac3 but I think it marks anything that should be researched as researched. Since .sv6 files have already used the research list it shouldn't be reset. I'm unsure why its crashing though. Perhaps this save was used with an old version of the scenario creator and the list is corrupted.

Fixes #1315.