### PR TITLE
Fix rotation and rides been on

### DIFF
--- a/src/windows/guest.c
+++ b/src/windows/guest.c
@@ -1566,8 +1566,8 @@ void window_guest_rides_update(){
 	uint8 curr_list_position = 0;
 	for (uint8 ride_id = 0; ride_id < 255; ++ride_id){
 		// Offset to the ride_id bit in peep_rides_been_on
-		uint8 ride_id_bit = ride_id & 0x1F;
-		uint8 ride_id_offset = ride_id / 32;
+		uint8 ride_id_bit = ride_id & 0x7;
+		uint8 ride_id_offset = ride_id / 8;
 		if (peep->rides_been_on[ride_id_offset] & (1 << ride_id_bit)){
 			rct_ride* ride = GET_RIDE(ride_id);
 			if (RCT2_ADDRESS(0x97C3AF, uint8)[ride->type] == 0){

--- a/src/windows/scenery.c
+++ b/src/windows/scenery.c
@@ -923,7 +923,7 @@ void window_scenery_invalidate()
 				window_scenery_widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type = WWT_FLATBTN;
 			}
 		}
-		else if (tabSelectedSceneryId > 0x300) {
+		else if (tabSelectedSceneryId >= 0x300) {
 			window_scenery_widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type = WWT_FLATBTN;
 		}
 	}


### PR DESCRIPTION
Fixes #1342 and #1336.

Fixes the issue with the rotation button going missing.

Fix the peep rides been on displaying incorrectly for parks with more than 8 rides. 