### PR TITLE
Check for duplicates when unloading objects

### DIFF
--- a/src/object/ObjectManager.cpp
+++ b/src/object/ObjectManager.cpp
@@ -176,6 +176,17 @@ public:
         {
             for (int i = 0; i < OBJECT_ENTRY_COUNT; i++)
             {
+                if (_loadedObjects[i] != nullptr)
+                {
+                    for (int j = i + 1; j < OBJECT_ENTRY_COUNT; j++)
+                    {
+                        if (_loadedObjects[j] == _loadedObjects[i])
+                        {
+                            Console::Error::WriteFormat("Duplicate found for %p", _loadedObjects[i]);
+                            Console::Error::WriteLine();
+                        }
+                    }
+                }
                 UnloadObject(_loadedObjects[i]);
                 _loadedObjects[i] = nullptr;
             }


### PR DESCRIPTION
rename to sv6

[roof_on_zoom1.txt](https://github.com/IntelOrca/OpenRCT2/files/355465/roof_on_zoom1.txt)

When a duplicate is found, on second time this object will get used after it was already removed in first instance.
