### PR TITLE
Add one more assert to decode_chunk_rle_with_size

### DIFF
--- a/src/util/sawyercoding.c
+++ b/src/util/sawyercoding.c
@@ -395,6 +395,7 @@ static size_t decode_chunk_rle_with_size(const uint8* src_buffer, uint8* dst_buf
 		if (rleCodeByte & 128) {
 			i++;
 			count = 257 - rleCodeByte;
+			assert(dst + count <= dst_buffer + dstSize);
 			memset(dst, src_buffer[i], count);
 			dst = (uint8*)((uintptr_t)dst + count);
 		} else {


### PR DESCRIPTION
```
#0  0xf7fd8d49 in __kernel_vsyscall ()
#1  0xf6b84eb9 in raise () from /usr/lib32/libc.so.6
#2  0xf6b863f7 in abort () from /usr/lib32/libc.so.6
#3  0xf6b7dc17 in __assert_fail_base () from /usr/lib32/libc.so.6
#4  0xf6b7dc9b in __assert_fail () from /usr/lib32/libc.so.6
#5  0x017c1df3 in decode_chunk_rle_with_size (src_buffer=0xf423a800 <incomplete sequence \371>, dst_buffer=0xe0dff800 "", length=806386, dstSize=6291456) at /home/janisozaur/workspace/OpenRCT2/src/util/sawyercoding.c:398
#6  0x017c088b in sawyercoding_read_chunk_with_size (rw=0xf43190d0, buffer=0xe0dff800 "", buffer_size=6291456) at /home/janisozaur/workspace/OpenRCT2/src/util/sawyercoding.c:193
#7  0x01b1e3d5 in ObjectFactory::GetDecodedChunkStream (context=0xffffc670, file=0xf43190d0) at /home/janisozaur/workspace/OpenRCT2/src/object/ObjectFactory.cpp:115
#8  0x01b1e862 in ObjectFactory::CreateObjectFromLegacyFile (path=0xf1f0db40 "/home/janisozaur/workspace/OpenRCT2/build-native/ObjData/BOAT.DAT") at /home/janisozaur/workspace/OpenRCT2/src/object/ObjectFactory.cpp:146
#9  0x01b3dd8e in ObjectRepository::ScanObject (this=0xf3910e10, path=0xf1f0db40 "/home/janisozaur/workspace/OpenRCT2/build-native/ObjData/BOAT.DAT") at /home/janisozaur/workspace/OpenRCT2/src/object/ObjectRepository.cpp:291
#10 0x01b3dbcf in ObjectRepository::ScanDirectory (this=0xf3910e10, directory=0xffffcbe0 "/home/janisozaur/workspace/OpenRCT2/build-native/ObjData") at /home/janisozaur/workspace/OpenRCT2/src/object/ObjectRepository.cpp:285
#11 0x01b3d6dc in ObjectRepository::Construct (this=0xf3910e10) at /home/janisozaur/workspace/OpenRCT2/src/object/ObjectRepository.cpp:267
#12 0x01b3b997 in ObjectRepository::LoadOrConstruct (this=0xf3910e10) at /home/janisozaur/workspace/OpenRCT2/src/object/ObjectRepository.cpp:126
#13 0x01b3624c in object_list_load () at /home/janisozaur/workspace/OpenRCT2/src/object/ObjectRepository.cpp:691
#14 0x01957b6d in rct2_init () at /home/janisozaur/workspace/OpenRCT2/src/rct2.c:167
#15 0x01975dd6 in openrct2_initialise () at /home/janisozaur/workspace/OpenRCT2/src/openrct2.c:241
#16 0x019760e2 in openrct2_launch () at /home/janisozaur/workspace/OpenRCT2/src/openrct2.c:269
#17 0x017fc005 in main (argc=1, argv=0xffffd344) at /home/janisozaur/workspace/OpenRCT2/src/platform/posix.c:60
```

[BOAT.dat.txt](https://github.com/IntelOrca/OpenRCT2/files/358144/BOAT.dat.txt)
